### PR TITLE
feat: read ALLOWED_HOSTS and CSRF_TRUSTED_ORIGINS from the environment

### DIFF
--- a/the_cult_film_club/settings.py
+++ b/the_cult_film_club/settings.py
@@ -59,16 +59,25 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 # Secret key for Django (should be kept secret in production)
 SECRET_KEY = os.environ.get("SECRET_KEY")
 
-# CSRF trusted origins for security
+# CSRF trusted origins for security. Read from the environment as a
+# comma-separated list so the same code runs on Railway and on the AWS box;
+# the default is the value that was previously hardcoded here, so leaving the
+# variable unset keeps the existing deployment unchanged.
 CSRF_TRUSTED_ORIGINS = [
-    "http://127.0.0.1:8000/",
-    "https://*.herokuapp.com",
-    "https://*.railway.app",
-    "https://*.vercel.app",
+    o.strip() for o in os.environ.get(
+        "CSRF_TRUSTED_ORIGINS",
+        "http://127.0.0.1:8000/,https://*.herokuapp.com,"
+        "https://*.railway.app,https://*.vercel.app",
+    ).split(",") if o.strip()
 ]
 
-# Allowed hosts for this Django site
-ALLOWED_HOSTS = ['localhost', '127.0.0.1', '.railway.app', '.vercel.app']
+# Allowed hosts for this Django site, same environment-driven approach.
+ALLOWED_HOSTS = [
+    h.strip() for h in os.environ.get(
+        "ALLOWED_HOSTS",
+        "localhost,127.0.0.1,.railway.app,.vercel.app",
+    ).split(",") if h.strip()
+]
 
 # Installed apps (Django, third-party, and project apps)
 INSTALLED_APPS = [


### PR DESCRIPTION
Both `ALLOWED_HOSTS` and `CSRF_TRUSTED_ORIGINS` were hardcoded to the Railway and Vercel domains, so serving the app from any other address meant editing `settings.py`. They now read from comma-separated environment variables.

**The defaults are exactly the values that were hardcoded before**, so with the variables unset nothing changes. Verified:

```
unset -> matches old ALLOWED_HOSTS:  True
unset -> matches old CSRF_TRUSTED:   True
```

Whitespace and empty entries are stripped, so a pasted `"a, b, c"` works.

**Why this matters for the AWS migration:** the same commit can run on Railway and on the new box, so cutover is reversible - if the new host misbehaves, DNS points back to Railway with no code change and no redeploy.