### PR TITLE
fix: use the modern stripe exception namespace

### DIFF
--- a/the_cult_film_club/apps/cart/views.py
+++ b/the_cult_film_club/apps/cart/views.py
@@ -366,7 +366,7 @@ def checkout(request):
                 'discount_code': discount_code,
             }
         )
-    except stripe.error.CardError as e:
+    except stripe.CardError as e:
         messages.error(
             request,
             e.user_message or (
@@ -375,7 +375,7 @@ def checkout(request):
         )
         return redirect(reverse('cart'))
 
-    except stripe.error.RateLimitError:
+    except stripe.RateLimitError:
         messages.error(
             request,
             (
@@ -385,7 +385,7 @@ def checkout(request):
         )
         return redirect(reverse('cart'))
 
-    except stripe.error.InvalidRequestError as e:
+    except stripe.InvalidRequestError as e:
         error_message = str(e)
         if (
             "payment_method_data[billing_details][address][country]"
@@ -403,14 +403,14 @@ def checkout(request):
         messages.error(request, user_msg)
         return redirect(reverse('cart'))
 
-    except stripe.error.AuthenticationError:
+    except stripe.AuthenticationError:
         messages.error(
             request,
             "Payment authentication failed. Please try again later."
         )
         return redirect(reverse('cart'))
 
-    except stripe.error.APIConnectionError:
+    except stripe.APIConnectionError:
         messages.error(
             request,
             (
@@ -420,7 +420,7 @@ def checkout(request):
         )
         return redirect(reverse('cart'))
 
-    except stripe.error.StripeError:
+    except stripe.StripeError:
         messages.error(
             request,
             (

--- a/the_cult_film_club/apps/cart/webhook_handler.py
+++ b/the_cult_film_club/apps/cart/webhook_handler.py
@@ -68,7 +68,7 @@ class StripeWH_Handler:
             try:
                 charge = stripe.Charge.retrieve(charge_id)
                 billing_details = charge.billing_details
-            except stripe.error.StripeError:
+            except stripe.StripeError:
                 return HttpResponse(
                     content=(
                         f'Webhook received: {event["type"]} | '

--- a/the_cult_film_club/apps/cart/webhooks.py
+++ b/the_cult_film_club/apps/cart/webhooks.py
@@ -30,7 +30,7 @@ def webhook(request):
     except ValueError as e:
         # Invalid payload
         return HttpResponse(f"Invalid payload: {e}", status=400)
-    except stripe.error.SignatureVerificationError as e:
+    except stripe.SignatureVerificationError as e:
         # Invalid signature
         return HttpResponse(f"Invalid signature: {e}", status=400)
     except Exception as e:


### PR DESCRIPTION
The Stripe Python library removed `stripe.error` in v12; `requirements.txt` pins `stripe==13.0.1`. Evaluating an `except stripe.error.X` clause raises `AttributeError` *while the original exception is being handled*, so it escapes before any later handler can catch it.

This was reported as a webhook issue, but it turned out to affect **8 sites across 3 files** - and the worst of them is in checkout, not the webhook.

### Checkout (`cart/views.py`) - the significant one

Six `except` clauses wrap `stripe.PaymentIntent.create`, each with a carefully written customer-facing message. **All of them were unreachable.** A customer whose card was declined got a 500 error page instead of:

> Your card was declined. Please try another payment method.

Same for rate limiting, invalid requests, authentication failures and connection errors.

### Webhook (`cart/webhooks.py`, `cart/webhook_handler.py`)

Returned 500 instead of 400 for a bad signature, so Stripe would log delivery failures as server errors rather than rejections.

### Not a security issue

Forged webhooks were always rejected - the exception propagated rather than being swallowed, so no handler ever ran on unverified data. This is a correctness and user-experience bug.

### Verified on the server

All seven exception classes confirmed present at the top level in the installed `stripe==13.0.1`, then tested before and after against the live endpoint:

```
BEFORE   VALID -> 200        FORGED -> 500  (Django error page)
AFTER    VALID -> 200        FORGED -> 400  "Invalid signature: No signatures
                                             found matching the expected
                                             signature for payload"
```

Signed events still process exactly as before. Change is mechanical - `stripe.error.X` to `stripe.X` - with no logic altered.