### PR TITLE
fix: order confirmation emails were never sent on the normal checkout path

### DIFF
--- a/the_cult_film_club/apps/cart/webhook_handler.py
+++ b/the_cult_film_club/apps/cart/webhook_handler.py
@@ -10,7 +10,10 @@ from the_cult_film_club.apps.releases.models import Releases
 
 import stripe
 import json
+import logging
 from decimal import Decimal
+
+logger = logging.getLogger(__name__)
 
 
 class StripeWH_Handler:
@@ -39,7 +42,17 @@ class StripeWH_Handler:
                 'email': settings.DEFAULT_FROM_EMAIL,
             }
         )
-        send_mail(subject, body, settings.DEFAULT_FROM_EMAIL, [cust_email])
+        # A mail failure must not fail the webhook. Returning a 500 to Stripe
+        # makes it retry the delivery, which would send the customer duplicate
+        # confirmations once mail recovered - and the order itself is already
+        # safely recorded by this point.
+        try:
+            send_mail(subject, body, settings.DEFAULT_FROM_EMAIL, [cust_email])
+        except Exception:
+            logger.exception(
+                "Failed to send confirmation email for order %s",
+                order.order_number,
+            )
 
     def handle_event(self, event):
         """
@@ -94,6 +107,12 @@ class StripeWH_Handler:
         # Check if the order already exists (idempotency)
         try:
             order = Order.objects.get(stripe_pid=pid)
+            # This is the normal path: the checkout view creates the order, so
+            # by the time the webhook arrives it is already here. The
+            # confirmation has to be sent from this branch too, otherwise a
+            # customer only ever gets one when checkout failed to complete and
+            # the webhook had to create the order below.
+            self._send_confirmation_email(order)
             return HttpResponse(
                 content=(
                     f'Webhook received: {event["type"]} | '

--- a/the_cult_film_club/apps/cart/webhook_handler.py
+++ b/the_cult_film_club/apps/cart/webhook_handler.py
@@ -30,9 +30,12 @@ class StripeWH_Handler:
         Sends order confirmation email to the user
         """
         cust_email = order.email
+        # conf_subject.txt reads {{ order.order_number }}, so the order itself
+        # has to be in the context - passing only order_number rendered the
+        # subject with an empty reference after the "#".
         subject = render_to_string(
             'cart/conf_subject.txt',
-            {'order_number': order.order_number}
+            {'order': order, 'order_number': order.order_number}
         ).strip()
         body = render_to_string(
             'cart/conf_body.txt',

--- a/the_cult_film_club/settings.py
+++ b/the_cult_film_club/settings.py
@@ -337,3 +337,36 @@ STRIPE_CURRENCY = 'gbp'
 STRIPE_PUBLIC_KEY = os.getenv('STRIPE_PUBLIC_KEY', '')
 STRIPE_SECRET_KEY = os.getenv('STRIPE_SECRET_KEY', '')
 STRIPE_WH_SECRET = os.getenv('STRIPE_WH_SECRET', '')
+
+# Django's default sends 500 tracebacks to ADMINS by email and prints nothing
+# when DEBUG is False. With no ADMINS set, unhandled exceptions vanished
+# silently. Writing to stderr instead puts them wherever the process log goes -
+# the console in development, the systemd journal in production.
+LOGGING = {
+    "version": 1,
+    "disable_existing_loggers": False,
+    "formatters": {
+        "verbose": {
+            "format": "{levelname} {asctime} {name} {message}",
+            "style": "{",
+        },
+    },
+    "handlers": {
+        "console": {
+            "class": "logging.StreamHandler",
+            "formatter": "verbose",
+        },
+    },
+    "loggers": {
+        "django.request": {
+            "handlers": ["console"],
+            "level": "ERROR",
+            "propagate": False,
+        },
+        "the_cult_film_club": {
+            "handlers": ["console"],
+            "level": "INFO",
+            "propagate": False,
+        },
+    },
+}


### PR DESCRIPTION
Found while verifying a test-mode purchase after the AWS migration: the order completed and appeared in the database, but no confirmation email arrived. Three separate defects, all pre-existing.

## 1. The email was never sent on a normal purchase

`_send_confirmation_email` was only called after the branch where the **webhook** creates the order. On a normal purchase the checkout view creates it first, so the webhook took the idempotency branch and returned 200 without sending anything.

Net effect: a customer only ever received a confirmation in the *fallback* case - when checkout failed to complete and the webhook had to create the order. On the happy path, nothing.

Fixed by sending from the idempotency branch too.

## 2. The subject line had no order number

`conf_subject.txt` renders `{{ order.order_number }}`, but only `order_number` was passed into its context, so every subject read:

```
Your Order Confirmation — The Cult Film Club #
```

The body was unaffected - it already received `order`. Fixed by passing `order` into the subject context as well.

## 3. Unhandled exceptions were invisible

Django sends 500 tracebacks to `ADMINS` by email and prints nothing when `DEBUG=False`. With no `ADMINS` configured, crashes vanished entirely - which is why a 500 on a real Stripe delivery could not be diagnosed. Added a `LOGGING` config writing to stderr, which reaches the systemd journal in production and the console in development.

Also made a mail failure non-fatal to the webhook: returning 500 causes Stripe to retry, which would send duplicate confirmations once mail recovered, and the order is already recorded by then. Failures are logged instead.

## Verified on the server

SMTP itself was never the problem - checked against Fastmail without sending anything:

```
TCP connect smtp.fastmail.com:587           OK
AUTH                                        OK
MAIL FROM <tcfc@dominicfrancis.co.uk>       250 Ok
RCPT TO   <cultfilmclubsu@...>              250 Ok
```

Email rendering, using Django in-memory backend so nothing was delivered:

```
subject: Your Order Confirmation — The Cult Film Club #8C659ED9163C44E39CE4BA848BB1E0E1
to:      cultfilmclubsu@dominicfrancis.co.uk
body:    Dear Super User, ... (ref: 8C659ED9163C44E39CE4BA848BB1E0E1)
```

Logging:

```
ERROR 2026-07-22 12:36:08,585 django.request LOGGING SELF TEST - this should be visible
```

Still needs a real end-to-end checkout to confirm delivery to a live inbox.