### PR TITLE
fix: disable django-ses client-side throttling

### DIFF
--- a/the_cult_film_club/settings.py
+++ b/the_cult_film_club/settings.py
@@ -30,6 +30,12 @@ if not DEBUG:
     EMAIL_BACKEND = "django_ses.SESBackend"
     AWS_SES_REGION_NAME = "eu-west-2"
     AWS_SES_REGION_ENDPOINT = "email.eu-west-2.amazonaws.com"
+    # django-ses throttles itself by calling ses:GetSendQuota before every
+    # send. That action cannot be scoped to a resource, so allowing it would
+    # mean granting it account-wide. This site sends a handful of messages a
+    # day against a 14/second limit that SES enforces server-side regardless,
+    # so the client-side throttle buys nothing worth widening IAM for.
+    AWS_SES_AUTO_THROTTLE = None
 
 # Custom user signup form for django-allauth
 ACCOUNT_FORMS = {


### PR DESCRIPTION
Follow-on from #100. The first real send through SES failed:

```
AccessDenied: User: .../apps-ec2-role/i-07bca300c5bb852d9 is not authorized
to perform: ses:GetSendQuota
```

`django-ses` calls `GetSendQuota` before each send so it can rate-limit itself.

## Why disable rather than grant the permission

`ses:GetSendQuota` **does not support resource-level permissions** - it can only be granted as `Resource: "*"`. That would be a wider grant than sending email itself, which is scoped to one verified identity and two specific from-addresses via an `ses:FromAddress` condition.

The site sends a handful of messages a day against a 14/second limit that SES enforces server-side regardless. The client-side throttle buys nothing worth widening the role for.

## Verified

With `AWS_SES_AUTO_THROTTLE = None`, a real send through the app on the server:

```
messages accepted by SES: 1
```