### PR TITLE
feat: email a notification when a contact enquiry arrives

### DIFF
--- a/the_cult_film_club/apps/contact/views.py
+++ b/the_cult_film_club/apps/contact/views.py
@@ -1,6 +1,12 @@
 from django.shortcuts import render, redirect
+from django.conf import settings
 from django.contrib import messages
+from django.core.mail import EmailMessage
+from django.utils.html import strip_tags
 from .forms import ContactUsForm
+import logging
+
+logger = logging.getLogger(__name__)
 
 
 def contact_us(request):
@@ -23,7 +29,33 @@ def contact_us(request):
         form = ContactUsForm(request.POST)
         if form.is_valid():
             # Save the valid form data to the database
-            form.save()
+            enquiry = form.save()
+
+            # The enquiry is stored above and visible in the admin, so this
+            # email is a notification rather than the record - without it an
+            # enquiry can sit unread indefinitely. A failure is logged and does
+            # not change what the visitor is told, because their message really
+            # was received; an error would only prompt a duplicate submission.
+            try:
+                EmailMessage(
+                    subject=(
+                        "Cult Film Club enquiry from "
+                        f"{enquiry.first_name} {enquiry.last_name}"
+                    ),
+                    # The message is a rich-text field, so the stored value is
+                    # HTML. Strip it for a readable plain-text notification.
+                    body=(
+                        f"Name: {enquiry.first_name} {enquiry.last_name}\n"
+                        f"Email: {enquiry.email}\n"
+                        f"Received: {enquiry.created:%d %b %Y %H:%M}\n\n"
+                        f"{strip_tags(enquiry.message)}"
+                    ),
+                    from_email=settings.DEFAULT_FROM_EMAIL,
+                    to=[settings.DEFAULT_FROM_EMAIL],
+                    reply_to=[enquiry.email],
+                ).send()
+            except Exception as e:
+                logger.exception("Contact enquiry notification failed: %s", e)
 
             # Add a success message to be displayed to the user
             messages.success(


### PR DESCRIPTION
The contact view saved the enquiry and told the visitor it had been received, but notified nobody - so an enquiry could sit unread in the admin indefinitely.

The database record stays as the source of truth; the email only surfaces it sooner. A send failure is logged and deliberately does **not** change what the visitor sees, because their message really was received - showing an error would only prompt a duplicate submission.

Details:
- The `message` field is `CKEditor5Field`, so the stored value is HTML. Tags are stripped for a readable plain-text notification.
- `Reply-To` is the enquirer, so replying goes to them rather than back to the site address.
- Sends from and to `tcfc@dominicfrancis.co.uk`, which the instance role is permitted to send as.

No Lambda or API Gateway needed - that pathway exists for the static sites, which have no server. This app has one, and now has a working SES backend.

## Verified on the server

Rendered with Django's in-memory backend, so nothing was delivered:

```
subject : Cult Film Club enquiry from Jane Doe
from    : tcfc@dominicfrancis.co.uk
to      : tcfc@dominicfrancis.co.uk
reply-to: jane@example.com
  | Name: Jane Doe
  | Email: jane@example.com
  | Received: 22 Jul 2026 13:05
  |
  | Do you ship to Ireland?
```

The HTML `<p>` and `<strong>` tags were correctly stripped.