### PR TITLE
ci: use configure-aws-credentials v6

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,7 +27,7 @@ jobs:
       # token for temporary credentials; the role only trusts this repo's main
       # branch and can only invoke the DeployApp document on the one instance.
       - name: Get temporary AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: arn:aws:iam::115019371912:role/github-actions-deploy
           aws-region: eu-west-2


### PR DESCRIPTION
`v4` runs on Node.js 20, which GitHub has deprecated. Every deploy produces:

```
Node.js 20 is deprecated. The following actions target Node.js 20 but are being
forced to run on Node.js 24: aws-actions/configure-aws-credentials@v4
```

`v6` (currently v6.2.2) targets Node 24 natively.

Neither breaking change affects this workflow:

- **v5.0.0** changed handling of *invalid boolean inputs* - none are passed here.
- **v6.0.0** is the Node 24 move itself, requiring runner v2.327.1+, which GitHub-hosted `ubuntu-latest` is well past.

This workflow only uses `role-to-assume` and `aws-region`.