### PR TITLE
infra: serve the images from CloudFront over a private bucket

### DIFF
--- a/infra/media-cdn.yaml
+++ b/infra/media-cdn.yaml
@@ -1,0 +1,159 @@
+AWSTemplateFormatVersion: "2010-09-09"
+
+Description: >-
+  Serves The Cult Film Club images from media.cultfilmclub.dominicfrancis.co.uk.
+  CloudFront distribution, the bucket policy that lets it read, and DNS.
+
+# Part of issue #116, and the step that makes infra/media-bucket.yaml usable.
+# The bucket blocks all public access, so until this stack exists nothing can
+# read an image from the internet.
+#
+# Deploy infra/media-certificate.yaml first, to us-east-1, and pass its output
+# here:
+#
+#   aws cloudformation deploy \
+#     --stack-name cultfilmclub-media-cdn \
+#     --template-file infra/media-cdn.yaml \
+#     --parameter-overrides CertificateArn=<arn from that stack> \
+#     --region eu-west-2 \
+#     --profile admin
+#
+# Expect 5 to 10 minutes: CloudFormation waits for the distribution to finish
+# deploying to every edge location.
+#
+# Still not here, and the last infrastructure piece of #116: s3:PutObject on the
+# bucket for apps-ec2-role, so uploads through the Django admin and the profile
+# form work. That modifies a shared role this stack does not own, which is why
+# it gets a stack of its own.
+
+Parameters:
+  CertificateArn:
+    Type: String
+    AllowedPattern: "^arn:aws:acm:us-east-1:[0-9]{12}:certificate/.+$"
+    ConstraintDescription: >-
+      Must be an ACM certificate ARN in us-east-1. CloudFront accepts
+      certificates from no other region.
+    Description: Output of the cultfilmclub-media-certificate stack in us-east-1.
+
+Resources:
+  # Origin Access Control replaces the old Origin Access Identity. The bucket
+  # stays private and CloudFront signs each origin request with SigV4; the
+  # bucket policy below is what trusts those signatures.
+  OriginAccessControl:
+    Type: AWS::CloudFront::OriginAccessControl
+    Properties:
+      OriginAccessControlConfig:
+        Name: cultfilmclub-media-oac
+        Description: Signs CloudFront reads of the the-cult-film-club bucket
+        OriginAccessControlOriginType: s3
+        SigningBehavior: always
+        SigningProtocol: sigv4
+
+  Distribution:
+    Type: AWS::CloudFront::Distribution
+    Properties:
+      DistributionConfig:
+        Enabled: true
+        Comment: The Cult Film Club images
+        Aliases:
+          - media.cultfilmclub.dominicfrancis.co.uk
+        HttpVersion: http2and3
+        IPV6Enabled: true
+        # Europe and North America only. The audience is a UK shop selling
+        # physical discs to UK addresses, and the cheaper class simply omits the
+        # edge locations furthest from it rather than refusing to serve anyone.
+        PriceClass: PriceClass_100
+
+        ViewerCertificate:
+          AcmCertificateArn: !Ref CertificateArn
+          SslSupportMethod: sni-only
+          MinimumProtocolVersion: TLSv1.2_2021
+
+        Origins:
+          - Id: MediaBucket
+            DomainName: !ImportValue cultfilmclub-media-bucket-domain
+            OriginAccessControlId: !GetAtt OriginAccessControl.Id
+            # Required by CloudFormation even for an S3 origin using OAC, and
+            # must be present and empty. A non-empty OriginAccessIdentity here
+            # would put the distribution back on the legacy mechanism.
+            S3OriginConfig:
+              OriginAccessIdentity: ""
+
+        DefaultCacheBehavior:
+          TargetOriginId: MediaBucket
+          ViewerProtocolPolicy: redirect-to-https
+          AllowedMethods: [GET, HEAD]
+          CachedMethods: [GET, HEAD]
+          Compress: true
+          # Managed-CachingOptimized. Caches on the path alone, forwarding no
+          # cookies, headers or query strings, which is right here because an
+          # image is the same file for every visitor. The id is a fixed AWS-wide
+          # constant, not an account-specific value.
+          CachePolicyId: 658327ea-f89d-4fab-a63d-7e88639e58f6
+
+      Tags:
+        - Key: Application
+          Value: cultfilmclub
+        - Key: ManagedBy
+          Value: cloudformation
+
+  # Lives here rather than in media-bucket.yaml because it has to name the
+  # distribution, which that stack knows nothing about. CloudFormation is
+  # content for a bucket policy to sit in a different stack from its bucket.
+  BucketPolicy:
+    Type: AWS::S3::BucketPolicy
+    Properties:
+      Bucket: !ImportValue cultfilmclub-media-bucket-name
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Sid: AllowCloudFrontRead
+            Effect: Allow
+            Principal:
+              Service: cloudfront.amazonaws.com
+            Action: s3:GetObject
+            Resource: !Sub
+              - "arn:aws:s3:::${Bucket}/*"
+              - Bucket: !ImportValue cultfilmclub-media-bucket-name
+            # Without this condition the grant would be to the CloudFront
+            # service rather than to this distribution, and any distribution in
+            # any AWS account could be pointed at the bucket and read it.
+            Condition:
+              StringEquals:
+                AWS:SourceArn: !Sub
+                  "arn:aws:cloudfront::${AWS::AccountId}:distribution/${Distribution}"
+
+  # Both records, because the distribution answers on IPv6 and a visitor on an
+  # IPv6-only network gets no address at all from the A record alone.
+  DnsIpv4:
+    Type: AWS::Route53::RecordSet
+    Properties:
+      HostedZoneId: Z04281911KACWXVUQESMB
+      Name: media.cultfilmclub.dominicfrancis.co.uk
+      Type: A
+      AliasTarget:
+        DNSName: !GetAtt Distribution.DomainName
+        # Fixed constant meaning "a CloudFront distribution", identical in every
+        # account and region. It is not this account's hosted zone.
+        HostedZoneId: Z2FDTNDATAQYW2
+        EvaluateTargetHealth: false
+
+  DnsIpv6:
+    Type: AWS::Route53::RecordSet
+    Properties:
+      HostedZoneId: Z04281911KACWXVUQESMB
+      Name: media.cultfilmclub.dominicfrancis.co.uk
+      Type: AAAA
+      AliasTarget:
+        DNSName: !GetAtt Distribution.DomainName
+        HostedZoneId: Z2FDTNDATAQYW2
+        EvaluateTargetHealth: false
+
+Outputs:
+  DistributionId:
+    Description: For cache invalidations after replacing an image
+    Value: !Ref Distribution
+
+  MediaUrl:
+    Description: Base URL for images, for the Django storage settings
+    Value: https://media.cultfilmclub.dominicfrancis.co.uk

--- a/infra/media-certificate.yaml
+++ b/infra/media-certificate.yaml
@@ -1,0 +1,63 @@
+AWSTemplateFormatVersion: "2010-09-09"
+
+Description: >-
+  TLS certificate for media.cultfilmclub.dominicfrancis.co.uk, the domain the
+  images are served from. Must be deployed to us-east-1.
+
+# Part of issue #116, between infra/media-bucket.yaml and infra/media-cdn.yaml.
+#
+# This is a separate stack for one reason: CloudFront only accepts certificates
+# from us-east-1, no matter where the distribution serves from or where its
+# origin lives. Everything else in this migration is eu-west-2, so splitting the
+# certificate out is the smallest way to satisfy that without moving the rest.
+#
+# CloudFormation exports cannot cross regions, so media-cdn.yaml takes the ARN
+# below as a parameter rather than importing it.
+#
+# The hostname follows media.<site>, matching media.tardisarchives.co.uk. It is
+# four labels deep because this site lives on a subdomain of a shared personal
+# domain rather than on one of its own. That keeps craftr, which is also still
+# on Cloudinary, free to take media.craftr.dominicfrancis.co.uk later without a
+# second decision. Nobody types or sees either hostname.
+#
+# To apply (note the region, it is not the usual one):
+#
+#   aws cloudformation deploy \
+#     --stack-name cultfilmclub-media-certificate \
+#     --template-file infra/media-certificate.yaml \
+#     --region us-east-1 \
+#     --profile admin
+#
+# The deploy blocks until the certificate is issued. Validation records are
+# written into the hosted zone automatically by the HostedZoneId below, so this
+# needs no manual DNS step, but it does usually sit for several minutes looking
+# as though it has stalled. It has not.
+
+Resources:
+  Certificate:
+    Type: AWS::CertificateManager::Certificate
+    Properties:
+      DomainName: media.cultfilmclub.dominicfrancis.co.uk
+      ValidationMethod: DNS
+      DomainValidationOptions:
+        # Naming the zone is what makes this automatic. Without it ACM still
+        # issues a CNAME to add, but waits for someone to add it by hand and the
+        # stack sits in CREATE_IN_PROGRESS until they do.
+        #
+        # This is the dominicfrancis.co.uk zone, not a zone of this site's own.
+        # The site is a subdomain of it, so validation records for a name four
+        # labels deep still belong here.
+        - DomainName: media.cultfilmclub.dominicfrancis.co.uk
+          HostedZoneId: Z04281911KACWXVUQESMB
+      Tags:
+        - Key: Application
+          Value: cultfilmclub
+        - Key: ManagedBy
+          Value: cloudformation
+
+Outputs:
+  CertificateArn:
+    Description: >-
+      Pass to media-cdn.yaml as its CertificateArn parameter. Not exported,
+      because exports are per-region and that stack is in eu-west-2.
+    Value: !Ref Certificate


### PR DESCRIPTION
Second infrastructure step of #116, and the one that makes #118 usable. Until this, the bucket blocked all public access and nothing could read an image from the internet.

Two stacks, because CloudFront accepts certificates only from us-east-1 while everything else here is eu-west-2. CloudFormation exports cannot cross regions, so `media-cdn.yaml` takes the certificate ARN as a parameter rather than importing it.

## The hostname

`media.cultfilmclub.dominicfrancis.co.uk`, following the `media.<site>` shape of `media.tardisarchives.co.uk`.

Four labels deep because this site sits on a subdomain of a shared personal domain rather than one of its own. The alternative was `media.dominicfrancis.co.uk`, which is shorter but would take the generic name for one of two sibling sites: craftr is still on the same Cloudinary account with its own migration open, and this way it takes `media.craftr.dominicfrancis.co.uk` later with no further decision. Nothing here is ever typed or seen by a visitor.

Every other site in the account already has its own certificate and its own distribution, so this shares nothing and adds no new pattern.

## Security

The bucket stays private. CloudFront signs each origin request with SigV4 through an Origin Access Control, and the bucket policy trusts those signatures. The policy is conditioned on this distribution's ARN rather than on the CloudFront service, so no other distribution in any other AWS account can be pointed at the bucket and read it.

## Deployed and verified

| Check | Result |
|---|---|
| `cfn-lint`, both templates | clean |
| Certificate | issued, DNS validated automatically |
| Stack `cultfilmclub-media-cdn` | CREATE_COMPLETE |
| DNS A record | resolves to four CloudFront addresses |
| Probe object fetched over HTTPS | 200, body correct |
| Same URL over HTTP | 301 to HTTPS |

The probe object was removed after testing. Distribution `EX9YUO5ELBIKS`.

## Cost

The distribution and certificate bill nothing at this size. CloudFront's 1TB out and 10 million requests a month is perpetual free tier rather than a trial, and a few hundred megabytes of artwork will not approach it. Both DNS records sit in an existing hosted zone, so no new zone charge.