### PR TITLE
fix: correct the image keys written by the Cloudinary migration

### DIFF
--- a/the_cult_film_club/apps/account/migrations/0017_correct_photograph_keys.py
+++ b/the_cult_film_club/apps/account/migrations/0017_correct_photograph_keys.py
@@ -1,0 +1,50 @@
+"""
+Corrects the keys written by 0016_prefix_photograph_keys.
+
+The counterpart of releases/0024_correct_image_keys, and the same mistake for
+the same reason. See that migration for the full explanation. The only
+differences are the prefix and the fact that only two rows are affected, the
+third already holding the site/placeholder default.
+"""
+
+import re
+
+from django.db import migrations
+
+CLOUDINARY_PATH = re.compile(
+    r"^(?P<prefix>profiles/)"
+    r"image/upload/v\d+/"
+    r"(?P<public_id>.+?)"
+    r"(?P<extension>\.[A-Za-z0-9]+)?$"
+)
+
+
+def correct_keys(apps, schema_editor):
+    Profile = apps.get_model("the_cult_film_club_account", "Profile")
+
+    for profile in Profile.objects.all().iterator():
+        value = profile.photograph.name or ""
+        match = CLOUDINARY_PATH.match(value)
+        if not match:
+            continue
+
+        corrected = f"{match['prefix']}{match['public_id']}"
+        Profile.objects.filter(pk=profile.pk).update(photograph=corrected)
+
+
+def unreversible(apps, schema_editor):
+    """
+    Deliberately does nothing. The Cloudinary version number cannot be
+    reconstructed, and the corrected key is the one that matches the bucket.
+    """
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("the_cult_film_club_account", "0016_prefix_photograph_keys"),
+    ]
+
+    operations = [
+        migrations.RunPython(correct_keys, unreversible),
+    ]

--- a/the_cult_film_club/apps/home/management/commands/copy_media_to_s3.py
+++ b/the_cult_film_club/apps/home/management/commands/copy_media_to_s3.py
@@ -140,13 +140,13 @@ class Command(BaseCommand):
         plan = {}
 
         for value in Images.objects.values_list("image", flat=True):
-            public_id = str(value)
+            public_id = self.public_id(value)
             if not public_id or public_id in DEFAULTS:
                 continue
             plan[public_id] = f"releases/{public_id}"
 
         for value in Profile.objects.values_list("photograph", flat=True):
-            public_id = str(value)
+            public_id = self.public_id(value)
             if not public_id or public_id in DEFAULTS:
                 continue
             plan[public_id] = f"profiles/{public_id}"
@@ -156,6 +156,31 @@ class Command(BaseCommand):
                 plan[public_id] = f"site/{public_id}"
 
         return sorted(plan.items())
+
+    @staticmethod
+    def public_id(value):
+        """
+        Reduces a stored value to the Cloudinary public id.
+
+        This exists because reading the column gave two different answers
+        depending on when you asked, which is what broke the first attempt at
+        this migration. While the field was a CloudinaryField the ORM decoded
+        the column and handed back the public id; once it became a plain
+        ImageField the same read returned the raw stored path:
+
+            image/upload/v1748091195/w2friuf7hyw7ajnmnmad.png
+
+        The data migration was written against the first behaviour and ran
+        under the second, so it prefixed the whole path. Taking the last
+        segment and dropping the extension gives the same answer under either,
+        and also under the corrected keys the rows hold now.
+        """
+        name = str(value or "")
+        if not name:
+            return ""
+
+        last_segment = name.rsplit("/", 1)[-1]
+        return last_segment.rsplit(".", 1)[0]
 
     def fetch(self, cloud_name, public_id):
         """

--- a/the_cult_film_club/apps/releases/migrations/0024_correct_image_keys.py
+++ b/the_cult_film_club/apps/releases/migrations/0024_correct_image_keys.py
@@ -1,0 +1,76 @@
+"""
+Corrects the keys written by 0023_prefix_image_keys.
+
+That migration assumed the column held a bare Cloudinary public id, because
+that is what reading the field through the ORM returned while it was still a
+CloudinaryField. It is not what the column held. The raw value was the whole
+Cloudinary resource path:
+
+    image/upload/v1748091195/w2friuf7hyw7ajnmnmad.png
+
+By the time 0023 ran, 0022 had already turned the field into a plain
+ImageField, which hands back the column untouched, so 0023 prefixed the whole
+path and produced keys that exist nowhere:
+
+    releases/image/upload/v1748091195/w2friuf7hyw7ajnmnmad.png
+
+The copy command read the same rows through the CloudinaryField and therefore
+wrote the objects under the public id alone, which is the key that is actually
+in the bucket:
+
+    releases/w2friuf7hyw7ajnmnmad
+
+So the objects are right and the rows are wrong. This strips the
+image/upload/v<version>/ segment and the extension, leaving the prefix and the
+public id.
+"""
+
+import re
+
+from django.db import migrations
+
+# The prefix is already correct and stays. Only what Cloudinary added around
+# the public id comes off.
+CLOUDINARY_PATH = re.compile(
+    r"^(?P<prefix>releases/)"
+    r"image/upload/v\d+/"
+    r"(?P<public_id>.+?)"
+    r"(?P<extension>\.[A-Za-z0-9]+)?$"
+)
+
+
+def correct_keys(apps, schema_editor):
+    Images = apps.get_model("releases", "Images")
+
+    for image in Images.objects.all().iterator():
+        value = image.image.name or ""
+        match = CLOUDINARY_PATH.match(value)
+        if not match:
+            # Already correct, or the site/ default. Left alone so a re-run
+            # is harmless.
+            continue
+
+        corrected = f"{match['prefix']}{match['public_id']}"
+        Images.objects.filter(pk=image.pk).update(image=corrected)
+
+
+def unreversible(apps, schema_editor):
+    """
+    Deliberately does nothing.
+
+    Reversing would mean putting the Cloudinary version number back, and that
+    number is not derivable from anything left in the row. Since the corrected
+    key is the one that matches the bucket, going back would only reinstate
+    values that point at nothing.
+    """
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("releases", "0023_prefix_image_keys"),
+    ]
+
+    operations = [
+        migrations.RunPython(correct_keys, unreversible),
+    ]


### PR DESCRIPTION
**Release artwork on the live site has been returning 403 since #122 deployed.** This fixes it. My mistake, explained below.

## What went wrong

The column never held what I thought it held.

Reading the field gave two different answers depending on when you asked. While it was a `CloudinaryField`, the ORM decoded the column and handed back a bare public id. That is what I saw when I scoped the work, and what the copy command saw when it built its plan. The raw column actually held the whole Cloudinary resource path:

    image/upload/v1748091195/w2friuf7hyw7ajnmnmad.png

`0022` turned the field into a plain `ImageField`, and `0023` ran immediately after it. By then the same read returned the column untouched, so `0023` prefixed the entire path:

    releases/image/upload/v1748091195/w2friuf7hyw7ajnmnmad.png

Meanwhile the copy command had read those rows while the field was still a `CloudinaryField`, so it wrote the objects under the public id alone:

    releases/w2friuf7hyw7ajnmnmad

**The bucket is right. The rows are wrong.** Nothing needs re-copying.

| | |
|---|---|
| Release rows affected | 161 of 161 |
| Profile rows affected | 2 of 3, the third already held the `site/` default |
| Objects in S3 needing any change | none |
| Broken URL | 403 |
| Correct URL | 200 |

## Why local testing did not catch it

My local database has no release rows, so `0023` ran against nothing and reported success. Every check I ran afterwards was on synthesised values I had constructed in the already-correct shape, which confirmed the URL builder rather than the migration. The scoping query used `str()` on the model field, which is exactly the decoded form that hid the real column contents.

The check that would have caught it was reading one raw column value out of production before writing the migration, rather than after.

## The fix

Strips the `image/upload/v<version>/` segment and the extension, leaving prefix plus public id. Rows that already look right, including the `site/` defaults and any upload made since the switch, are left alone, so a re-run is harmless.

Not reversible, and deliberately so: the Cloudinary version number cannot be reconstructed from what is left in the row, and the corrected key is the one that matches the bucket. Reversing would only reinstate values pointing at nothing.

## Also hardened

`copy_media_to_s3` would now double the prefix if anyone ran it again, because the field type changed underneath it. It reduces a stored value to its public id by taking the last path segment and dropping the extension, which gives the same answer under the old field, the broken keys and the corrected ones.

## Verified

| Check | Result |
|---|---|
| Correction applied to the 3 real production values | all correct |
| Already-correct value left untouched | yes |
| `site/holding_image` left untouched | yes |
| A hypothetical post-fix upload left untouched | yes |
| `manage.py check` | no issues |
| `makemigrations --check --dry-run` | no changes detected |
| Both migrations apply locally | OK |
| PEP 8 at 79 columns | clean |

The regex was tested against values read out of the production database rather than invented ones. I will confirm the live pages after this deploys.
