### PR TITLE
feat(infra): replicate release artwork and site assets off site

### DIFF
--- a/infra/media-bucket.yaml
+++ b/infra/media-bucket.yaml
@@ -50,6 +50,20 @@ Description: >-
 #      uploads work. That belongs with the other instance-role grants and is a
 #      change to a role this stack does not own.
 
+Parameters:
+  BackupAccountId:
+    Type: String
+    Default: "639175159992"
+    AllowedPattern: "^[0-9]{12}$"
+    Description: >-
+      The backup account that release artwork and site assets replicate into.
+      See tardis-archives issue #14. The rest of that work lives in
+      doubleslash-studio/infra/, because a backup account is account-wide
+      rather than specific to this application. Only the rule below is here,
+      and only because CloudFormation requires it: a replication rule is a
+      property of the bucket resource, and one resource can be owned by
+      exactly one stack.
+
 Resources:
   MediaBucket:
     Type: AWS::S3::Bucket
@@ -89,6 +103,77 @@ Resources:
       # lifecycle rule would only add a way to lose something.
       VersioningConfiguration:
         Status: Enabled
+
+      # tardis-archives issue #14. Versioning above protects against accident.
+      # It does not protect against intent: anyone holding credentials in this
+      # account can purge every version in one API call, which is exactly what
+      # happened to the tardis-archives covers on 12 August 2026.
+      #
+      # So a copy goes to an account those credentials do not reach, into a
+      # bucket where Object Lock in compliance mode makes deletion impossible
+      # for anyone at all, including that account's root user and AWS Support.
+      #
+      # profiles/ is deliberately absent, and that absence is the point rather
+      # than an oversight.
+      #
+      # Profile photographs are personal data uploaded through the profile
+      # form, and an erasure request has to actually erase them. Compliance
+      # mode cannot be shortened by anyone, so a replicated profile photograph
+      # could not be removed until its retention expired. The lock runs from
+      # when the file was written rather than from the request, so most would
+      # already be free, but the margin would be gone and nothing could
+      # restore it. Leaving them out keeps erasure working as designed, and
+      # they are the least costly thing here to lose: the member still has the
+      # original and can upload it again, which is not true of release
+      # artwork.
+      #
+      # Two rules rather than one with two prefixes, because a replication
+      # filter matches a single prefix and there is no way to write an either
+      # or. Priorities only settle overlapping rules, and these do not
+      # overlap, so the numbers are just labels.
+      #
+      # DeleteMarkerReplication is Disabled, so removing an image here leaves
+      # the backup copy alone. Deletes that name a specific version are never
+      # replicated whatever this says, which is the property that would have
+      # saved the covers in August.
+      #
+      # Adding this updates the bucket in place. CloudFormation does not
+      # replace a bucket to add replication, so existing objects are
+      # untouched. They are also not copied: replication only applies to
+      # writes made after the rule exists, so the images already here need a
+      # one off S3 Batch Replication job.
+      ReplicationConfiguration:
+        # Cross-stack import. The role lives in
+        # doubleslash-backup-replication-role, in this same account. The
+        # import makes that stack undeletable while this rule refers to it,
+        # which is the correct dependency rather than an inconvenience.
+        Role: !ImportValue backup-replication-role-arn
+        Rules:
+          - Id: releases-to-backup-account
+            Status: Enabled
+            Priority: 1
+            Filter:
+              Prefix: releases/
+            DeleteMarkerReplication:
+              Status: Disabled
+            Destination:
+              Bucket: !Sub "arn:aws:s3:::doubleslash-backup-the-cult-film-club-${BackupAccountId}"
+              # Naming the expected owner turns a misdirected rule into an
+              # error instead of a silent copy to a stranger's bucket.
+              Account: !Ref BackupAccountId
+              StorageClass: STANDARD
+
+          - Id: site-assets-to-backup-account
+            Status: Enabled
+            Priority: 2
+            Filter:
+              Prefix: site/
+            DeleteMarkerReplication:
+              Status: Disabled
+            Destination:
+              Bucket: !Sub "arn:aws:s3:::doubleslash-backup-the-cult-film-club-${BackupAccountId}"
+              Account: !Ref BackupAccountId
+              StorageClass: STANDARD
 
       Tags:
         - Key: Application


### PR DESCRIPTION
Part of [tardis-archives#14](https://github.com/dvfrancis/tardis-archives/issues/14). Pairs with the same change in [craftr#120](https://github.com/dvfrancis/craftr/pull/120).

**Deploy [doubleslash-studio#54](https://github.com/doubleslash-studio/doubleslash-studio/pull/54) first.** This imports `backup-replication-role-arn` and names a bucket that PR creates.

## Why

Versioning protects against accident. It does not protect against intent. Anyone holding credentials in this account can purge every version of every object in a single API call, which is exactly what happened to the tardis-archives covers on 12 August 2026, when 1,434 versions went in one call.

The fix is a copy in an account those credentials do not reach, in a bucket where Object Lock in compliance mode makes deletion impossible for anyone at all, including that account's root user and AWS Support.

## What is and is not replicated

| Prefix | Replicated | Why |
|---|---|---|
| `releases/` | Yes | Release artwork. Irreplaceable. |
| `site/` | Yes | Decorative assets referenced directly by the templates. |
| `profiles/` | **No** | Personal data. See below. |

**`profiles/` is deliberately excluded, and the absence is the point.**

Those are member profile photographs uploaded through the profile form, and an erasure request has to actually erase them. Compliance mode cannot be shortened by anyone, so a replicated profile photograph could not be deleted until its retention expired. The lock runs from when a file was written rather than from when the request arrives, so most would already be free, but the margin disappears and nothing can restore it.

They are also the cheapest thing here to lose. The member still has the original and can upload it again, which is not true of release artwork.

## Shape of the rule

Two rules rather than one with two prefixes, because a replication filter matches a single prefix and there is no way to express an either or. The priorities only settle overlapping rules, and these do not overlap, so the numbers are just labels.

`DeleteMarkerReplication` is Disabled, so deleting an image here leaves the backup alone. Deletes naming a specific version are never replicated regardless, which is the property that would have saved the covers in August.

`Account` names the expected owner, turning a misdirected rule into an error rather than a silent copy into a stranger's bucket.

## Effect on this bucket

None. The change is additive and CloudFormation updates the bucket in place rather than replacing it, so existing images and versions are untouched.

They are also not copied. Replication only applies to writes made after the rule exists, so the images already here need a one off S3 Batch Replication job, which is a manual step costing about 25p.

## Verification

`cfn-lint` clean. 85 insertions, 0 deletions.
