### PR TITLE
ci: skip deploys for documentation-only changes

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,6 +7,27 @@ name: Deploy
 on:
   push:
     branches: [main]
+    # Documentation does not reach the running site, so changing it should not
+    # pull, install, migrate and restart the service. Merging #107 - one new
+    # markdown file, no application code - did exactly that.
+    #
+    # Listed file by file rather than as a **.md glob, deliberately. Markdown
+    # exists inside staticfiles/ as vendored licences and changelogs, and a
+    # change under there means the collected static assets have moved, which
+    # very much does need deploying. A glob would silently skip that.
+    #
+    # documentation/ is 42 screenshots and PDFs that README.md and TESTING.md
+    # link to. Nothing serves them.
+    #
+    # Anything absent from this list still deploys, so requirements.txt,
+    # templates, this workflow and every line of Python are unaffected. A push
+    # touching both documentation and code deploys, because the filter only
+    # skips when every changed file matches.
+    paths-ignore:
+      - 'README.md'
+      - 'TESTING.md'
+      - 'CLAUDE.md'
+      - 'documentation/**'
   workflow_dispatch:      # so a deploy can also be triggered by hand
 
 # One deploy at a time. Without this, two quick merges could have the box


### PR DESCRIPTION
Closes #114.

Merging #107 added a single markdown file, touched no application code, and still ran a full deploy: pull, install, migrate, restart, smoke test. 60 seconds of restarting the live site for a file the site never serves.

## The list is explicit, not a glob

The issue asked whether to use `**.md` or name the files. Naming them, and the reason is concrete:

    staticfiles/admin/css/vendor/select2/LICENSE-SELECT2.md
    staticfiles/ckeditor/ckeditor/CHANGES.md
    staticfiles/ckeditor/ckeditor/README.md

`staticfiles/` is committed and contains vendored markdown. A change under there means the collected static assets have moved, which very much does need deploying. A `**.md` glob would have skipped it silently, and the failure mode is stale assets in production with a green deploy history showing nothing wrong.

| Ignored | Why |
|---|---|
| `README.md`, `TESTING.md`, `CLAUDE.md` | The three root documents. Nothing serves them |
| `documentation/**` | 42 screenshots and PDFs those two link to |

Everything else still deploys: `requirements.txt`, templates, static sources, every line of Python, and this workflow itself.

## Behaviour worth stating

`paths-ignore` only skips when **every** changed file matches. A push touching both a template and `README.md` still deploys, so this cannot cause a code change to be missed by bundling it with documentation.

`workflow_dispatch` is unaffected, so a deploy can still be forced by hand at any time.

## Verified

| Check | Result |
|---|---|
| YAML parses | yes |
| `branches` | `['main']`, unchanged |
| `paths-ignore` | the four entries above |
| `workflow_dispatch` | still present |
| Concurrency group | `deploy-cultfilmclub`, `cancel-in-progress: false`, unchanged |
| Permissions | `id-token: write`, `contents: read`, unchanged |
| Job steps | 2, unchanged |

Rollback behaviour lives in the SSM document on the box and is untouched.

The real proof comes next: #113 is a documentation-only change to `README.md`, so once this is merged that one should produce no deploy at all.