### PR TITLE
fix: set the missing production security settings

### DIFF
--- a/the_cult_film_club/settings.py
+++ b/the_cult_film_club/settings.py
@@ -12,6 +12,66 @@ SITE_ID = 1
 # Debug mode (should be False in production)
 DEBUG = os.environ.get('DEBUG', 'False') == 'True'
 
+# Production security, gated on DEBUG the same way the email backend below is.
+# Every one of these is wrong locally, where runserver speaks plain HTTP and
+# enabling them would make the site unreachable.
+if not DEBUG:
+    # TLS terminates at nginx on the apps box, on a Let's Encrypt certificate
+    # managed by certbot. gunicorn listens on plain HTTP on 127.0.0.1:8002, so
+    # every request Django sees arrives unencrypted and it judges them all
+    # insecure. This is what tells it otherwise, and it has to come first:
+    # without it SECURE_SSL_REDIRECT would redirect a request that is already
+    # HTTPS, then redirect it again, forever, and the cookies below would
+    # never be sent at all.
+    #
+    # Trusting a header is only safe when nothing can set it but the proxy.
+    # gunicorn binds to loopback, so nothing reaches it except nginx, and
+    # nginx sets X-Forwarded-Proto itself on every proxied request rather than
+    # passing a client's through.
+    SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
+
+    # nginx already answers port 80 with a 301, so this is a second line of
+    # defence rather than the only one. Worth having: it stops the redirect
+    # depending on a web server configuration that lives in another repository
+    # and could be changed without anyone touching this one.
+    SECURE_SSL_REDIRECT = True
+
+    # The reason this issue was raised. Both default to False, so the session
+    # and CSRF cookies were being sent over plain HTTP if a request ever
+    # reached the site that way, on a site that authenticates people and takes
+    # card payments.
+    SESSION_COOKIE_SECURE = True
+    CSRF_COOKIE_SECURE = True
+
+    # HSTS tells a browser to refuse plain HTTP for this host for this long,
+    # and it is cached client-side, so a wrong value cannot be withdrawn - it
+    # has to expire. One hour to begin with, which is long enough to be real
+    # and short enough that a mistake costs an hour rather than a year. Raise
+    # it to 31536000 once this has run for a while.
+    SECURE_HSTS_SECONDS = 3600
+
+    # Covers media.cultfilmclub.dominicfrancis.co.uk, the only subdomain of
+    # this host. That is CloudFront, whose viewer policy is redirect-to-https,
+    # so it already refuses to serve anything over plain HTTP.
+    SECURE_HSTS_INCLUDE_SUBDOMAINS = True
+
+    # Django also asks for SECURE_HSTS_PRELOAD, and it is deliberately absent.
+    #
+    # The preload list is keyed on the registrable domain, so this site cannot
+    # be submitted on its own: the entry would be dominicfrancis.co.uk, which
+    # would force HTTPS on craftr, hi-lo, older-and-wider and everything else
+    # sharing that domain. Removal from the list takes months. That is a
+    # decision about the whole domain rather than about this application, and
+    # it is not one to make from here.
+    #
+    # The token would also contradict the max-age above: preload submissions
+    # require a year, and this declares an hour. Setting it would put a claim
+    # in the header that is both inert and untrue.
+    #
+    # Silenced rather than left as a standing warning, so that a future
+    # `check --deploy` reporting something is reporting something new.
+    SILENCED_SYSTEM_CHECKS = ["security.W021"]
+
 # Email is sent through Amazon SES, which has dominicfrancis.co.uk verified
 # with DKIM, so any address on the domain can send.
 #


### PR DESCRIPTION
Closes #109.

The issue left one question open before implementing: where TLS terminates. Answered from the box.

## Where TLS terminates

`/etc/nginx/conf.d/cultfilmclub.conf`: nginx holds a certbot-managed Let's Encrypt certificate, terminates TLS, and proxies to gunicorn on `127.0.0.1:8002` over plain HTTP. It already sets `X-Forwarded-Proto $scheme`, and a second server block answers port 80 with a 301.

So this is the proxy case, and `SECURE_PROXY_SSL_HEADER` is mandatory rather than optional. Without it Django judges every proxied request insecure, `SECURE_SSL_REDIRECT` redirects a request that is already HTTPS and does so forever, and the secure cookies below are never sent at all.

Trusting a header is only safe when nothing but the proxy can set it. gunicorn binds to loopback, so nothing reaches it except nginx, and nginx sets the header itself rather than passing a client's through.

## What changed

All gated on `DEBUG`, matching how the email backend already switches between the console and SES.

| Setting | Value | Note |
|---|---|---|
| `SECURE_PROXY_SSL_HEADER` | `("HTTP_X_FORWARDED_PROTO", "https")` | Has to come first, see above |
| `SECURE_SSL_REDIRECT` | `True` | Second line of defence; nginx already 301s port 80 |
| `SESSION_COOKIE_SECURE` | `True` | The actual defect |
| `CSRF_COOKIE_SECURE` | `True` | The actual defect |
| `SECURE_HSTS_SECONDS` | `3600` | Deliberately an hour, not a year |
| `SECURE_HSTS_INCLUDE_SUBDOMAINS` | `True` | Covers the media CloudFront host, already HTTPS-only |

`SECURE_SSL_REDIRECT` is redundant with nginx today. It is worth having because it stops the redirect depending on a web server configuration that lives in another repository and could be changed without anyone touching this one.

**HSTS starts short on purpose.** The directive is cached by the browser, so a wrong value cannot be withdrawn, only waited out. An hour is long enough to be real and short enough that a mistake costs an hour. Worth raising to `31536000` once this has run for a while, which is a one-line follow-up rather than part of this.

## One deviation from the acceptance criteria

The issue asked for `check --deploy` to be clean. It now reports `no issues (1 silenced)` rather than zero checks run, because I have **not** set `SECURE_HSTS_PRELOAD` and have silenced `security.W021` instead.

Two reasons, and I would rather state them than quietly comply:

- The preload list is keyed on the **registrable domain**. This site cannot be submitted on its own; the entry would be `dominicfrancis.co.uk`, which would force HTTPS on craftr, hi-lo, older-and-wider and everything else sharing it. Removal takes months. That is a decision about the whole domain, not about this application.
- Preload submissions require a max-age of a year. This declares an hour. The token would be both inert and untrue.

Silenced rather than left standing so that a future `check --deploy` reporting something is reporting something new. The reasoning is in a comment at the setting, per the convention in `settings.py`.

## The deploy will not roll itself back

Worth checking before merging, because `SECURE_SSL_REDIRECT` turning a 200 into a 301 would fail the smoke test and trigger a rollback.

`deploy-app`'s `smoke()` sends `-H "X-Forwarded-Proto: https"` alongside the Host header, so it is already covered. I ran the real thing rather than assuming:

| Request | Result |
|---|---|
| Exactly what `smoke()` sends | **200** |
| Same request with no proxy header | 301 to `https://cultfilmclub.dominicfrancis.co.uk/` |
| Response header on a proxied-https request | `Strict-Transport-Security: max-age=3600; includeSubDomains` |
| `Set-Cookie` on `/accounts/login/` | `csrftoken=…; SameSite=Lax; Secure` |

No `preload` token in the HSTS header, as intended.

## Verified

| Check | Result |
|---|---|
| `check --deploy`, `DEBUG=False` | no issues, 1 silenced |
| `check`, `DEBUG=True` | no issues, 0 silenced |
| All seven settings under `DEBUG=False` | as tabled above |
| All seven under `DEBUG=True` | Django defaults, nothing applied |
| PEP 8 at 79 columns | clean |

Local development is untouched: runserver still speaks plain HTTP and sets no secure cookies, which is what makes it usable.

## Noticed in passing, not fixed here

The nginx config comment still says "Cloudinary hosts the images". That file lives in `apps-box-config`, not this repository, so it is out of scope for this PR.
