### PR TITLE
test: add an automated test suite and run it on pull requests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,85 @@
+name: Tests
+
+# Runs the suite on every pull request, and again on main after merge.
+#
+# The point of the pull request run is to gate merging: deploy.yml fires on
+# push to main and goes straight to the live instance, so a test that only ran
+# after the merge would be reporting a regression that had already shipped.
+#
+# Making this required is a branch protection setting rather than anything in
+# this file. Without that, a red run here is advisory and the merge button
+# still works.
+on:
+  pull_request:
+  push:
+    branches: [main]
+    # Same list as deploy.yml, for the same reason: documentation cannot break
+    # the suite, so running it would only add a minute to every typo fix.
+    paths-ignore:
+      - 'README.md'
+      - 'TESTING.md'
+      - 'CLAUDE.md'
+      - 'documentation/**'
+
+concurrency:
+  group: tests-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    services:
+      # Postgres rather than SQLite, because production is Postgres and the
+      # project has migrations and queries that would not be exercised the
+      # same way on another backend.
+      postgres:
+        image: postgres:18
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: test_the_cult_film_club
+        ports:
+          - 5432:5432
+        # Without this the job races the container and the first connection
+        # is refused while Postgres is still starting.
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    env:
+      # This container has ssl off, so the ssl_require clause in settings.py
+      # would refuse every connection with "server does not support SSL".
+      # Production sets nothing and keeps requiring it.
+      DATABASE_SSL_REQUIRE: 'False'
+      DATABASE_URL: postgres://postgres:postgres@localhost:5432/test_the_cult_film_club
+      # Not a secret. It exists because settings.py requires one to import,
+      # and nothing in the suite signs anything that outlives the job.
+      SECRET_KEY: key-used-only-by-ci
+      # Left off deliberately, so the suite runs against settings as close to
+      # production as they can be. settings.py skips the HTTPS redirect while
+      # testing, which would otherwise answer every test client request with
+      # a 301.
+      DEBUG: 'False'
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+          cache: pip
+
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+
+      - name: Check for missing migrations
+        # Catches a model changed without makemigrations, which would other
+        # wise only surface on the box mid-deploy, after the snapshot and
+        # part-way through the restart.
+        run: python manage.py makemigrations --check --dry-run
+
+      - name: Run the test suite
+        run: python manage.py test --verbosity 2

--- a/the_cult_film_club/apps/about/tests.py
+++ b/the_cult_film_club/apps/about/tests.py
@@ -1,3 +1,19 @@
-from django.test import TestCase
+"""
+Tests for the about page.
 
-# Create your tests here.
+Static content, so there is little logic to exercise. What is worth asserting
+is that the page still renders, since it shares the base template with
+everything else and would break with it.
+"""
+
+from django.test import TestCase
+from django.urls import reverse
+
+
+class AboutPageTests(TestCase):
+    def test_the_about_page_renders(self):
+        self.assertEqual(self.client.get(reverse("about")).status_code, 200)
+
+    def test_the_about_page_includes_the_site_name(self):
+        response = self.client.get(reverse("about"))
+        self.assertContains(response, "Cult Film Club")

--- a/the_cult_film_club/apps/account/tests.py
+++ b/the_cult_film_club/apps/account/tests.py
@@ -1,3 +1,170 @@
-from django.test import TestCase
+"""
+Tests for profiles, addresses and wishlists.
 
-# Create your tests here.
+The profile photograph tests matter because #116 changed how deletion works:
+it used to erase the Cloudinary asset, and now blanks the column and leaves
+the S3 object, since the instance role holds no delete permission.
+"""
+
+from decimal import Decimal
+
+from django.contrib.auth.models import User
+from django.test import TestCase
+from django.urls import reverse
+from django.utils import timezone
+
+from the_cult_film_club.apps.account.models import (
+    Address,
+    Profile,
+    Wishlist,
+    WishlistItem,
+)
+from the_cult_film_club.apps.releases.models import Releases
+
+
+def make_user(username="ada", password="pw-for-test"):
+    return User.objects.create_user(
+        username=username, email=f"{username}@example.com", password=password
+    )
+
+
+class ProfileSignalTests(TestCase):
+    def test_a_profile_is_created_with_the_user(self):
+        user = make_user()
+        self.assertTrue(Profile.objects.filter(user=user).exists())
+
+    def test_saving_a_user_again_does_not_create_a_second_profile(self):
+        user = make_user()
+        user.first_name = "Ada"
+        user.save()
+        self.assertEqual(Profile.objects.filter(user=user).count(), 1)
+
+    def test_a_new_profile_uses_the_placeholder(self):
+        user = make_user()
+        self.assertEqual(user.profile.photograph.name, "site/placeholder")
+
+    def test_the_placeholder_is_served_from_cloudfront(self):
+        user = make_user()
+        self.assertTrue(
+            user.profile.photograph.url.startswith(
+                "https://media.cultfilmclub"
+            )
+        )
+
+    def test_deleting_a_user_deletes_the_profile(self):
+        user = make_user()
+        user.delete()
+        self.assertEqual(Profile.objects.count(), 0)
+
+
+class ProfilePhotoTests(TestCase):
+    def setUp(self):
+        self.user = make_user()
+        self.client.login(username="ada", password="pw-for-test")
+        self.profile = self.user.profile
+
+    def test_deleting_a_photo_restores_the_placeholder(self):
+        self.profile.photograph = "profiles/some_upload"
+        self.profile.save()
+
+        self.client.post(reverse("user_profile"), {"delete_photo": "1"})
+
+        self.profile.refresh_from_db()
+        self.assertEqual(self.profile.photograph.name, "site/placeholder")
+
+    def test_deleting_when_there_is_no_photo_changes_nothing(self):
+        self.client.post(reverse("user_profile"), {"delete_photo": "1"})
+        self.profile.refresh_from_db()
+        self.assertEqual(self.profile.photograph.name, "site/placeholder")
+
+
+class AddressTests(TestCase):
+    def setUp(self):
+        self.user = make_user()
+
+    def make_address(self, label="Home", default=False):
+        return Address.objects.create(
+            user=self.user,
+            first_line="1 Example Street",
+            city="London",
+            postcode="SW1A 1AA",
+            country="GB",
+            label=label,
+            default_address=default,
+        )
+
+    def test_a_second_default_address_unsets_the_first(self):
+        first = self.make_address("Home", default=True)
+        self.make_address("Work", default=True)
+
+        first.refresh_from_db()
+        self.assertFalse(first.default_address)
+
+    def test_only_one_address_is_ever_the_default(self):
+        self.make_address("Home", default=True)
+        self.make_address("Work", default=True)
+        self.make_address("Parents", default=True)
+        self.assertEqual(
+            Address.objects.filter(
+                user=self.user, default_address=True
+            ).count(),
+            1,
+        )
+
+    def test_another_users_default_is_not_affected(self):
+        other_user = make_user("grace")
+        other = Address.objects.create(
+            user=other_user,
+            first_line="2 Example Street",
+            city="London",
+            postcode="SW1A 2AA",
+            country="GB",
+            label="Home",
+            default_address=True,
+        )
+        self.make_address("Home", default=True)
+
+        other.refresh_from_db()
+        self.assertTrue(other.default_address)
+
+
+class WishlistTests(TestCase):
+    def setUp(self):
+        self.user = make_user()
+        self.release = Releases.objects.create(
+            title="Tourist Trap",
+            release_date=timezone.now().date(),
+            price=Decimal("19.99"),
+        )
+
+    def test_an_item_can_be_added_to_a_wishlist(self):
+        wishlist = Wishlist.objects.create(user=self.user, name="Mine")
+        WishlistItem.objects.create(wishlist=wishlist, title=self.release)
+        self.assertEqual(wishlist.wishlistitem_set.count(), 1)
+
+    def test_a_wishlist_defaults_to_medium_priority(self):
+        wishlist = Wishlist.objects.create(user=self.user, name="Mine")
+        item = WishlistItem.objects.create(
+            wishlist=wishlist, title=self.release
+        )
+        self.assertEqual(item.priority, "Medium")
+
+    def test_deleting_a_wishlist_removes_its_items(self):
+        wishlist = Wishlist.objects.create(user=self.user, name="Mine")
+        WishlistItem.objects.create(wishlist=wishlist, title=self.release)
+        wishlist.delete()
+        self.assertEqual(WishlistItem.objects.count(), 0)
+
+
+class ProfileAccessTests(TestCase):
+    def test_the_profile_page_requires_login(self):
+        response = self.client.get(reverse("user_profile"))
+        self.assertEqual(response.status_code, 302)
+        self.assertIn("/accounts/login/", response.url)
+
+    def test_a_logged_in_user_sees_their_profile(self):
+        make_user()
+        self.client.login(username="ada", password="pw-for-test")
+        self.assertEqual(
+            self.client.get(reverse("user_profile")).status_code, 200
+        )

--- a/the_cult_film_club/apps/cart/tests.py
+++ b/the_cult_film_club/apps/cart/tests.py
@@ -1,3 +1,408 @@
-from django.test import TestCase
+"""
+Tests for the cart: order totals, line items, discount codes and the webhook.
 
-# Create your tests here.
+This is the money path, so it is covered first and most thoroughly. Every
+figure here is checked against settings.FREE_DELIVERY and DELIVERY_RATE rather
+than against a literal, so changing either does not silently invalidate the
+tests.
+"""
+
+from datetime import timedelta
+from decimal import Decimal
+from uuid import uuid4
+
+from django.conf import settings
+from django.contrib.auth.models import User
+from django.test import TestCase
+from django.urls import reverse
+from django.utils import timezone
+
+from the_cult_film_club.apps.cart.models import (
+    DiscountCode,
+    Order,
+    OrderLineItem,
+)
+from the_cult_film_club.apps.releases.models import Releases
+
+
+def make_release(title="Tourist Trap", price="19.99", copies=5):
+    return Releases.objects.create(
+        title=title,
+        release_date=timezone.now().date(),
+        price=Decimal(price),
+        copies_available=copies,
+    )
+
+
+def make_order(**kwargs):
+    """
+    Every order gets its own stripe_pid.
+
+    That field is unique with a default of "", so a second order left without
+    one violates the constraint. Only one order can ever exist without a
+    payment intent, which is a real property of the model rather than a
+    quirk of these tests.
+    """
+    defaults = {
+        "full_name": "Ada Lovelace",
+        "email": "ada@example.com",
+        "phone_number": "01234567890",
+        "country": "GB",
+        "postcode": "SW1A 1AA",
+        "town_or_city": "London",
+        "street_address1": "1 Example Street",
+        "stripe_pid": f"pi_test_{uuid4().hex}",
+    }
+    defaults.update(kwargs)
+    return Order.objects.create(**defaults)
+
+
+class OrderNumberTests(TestCase):
+    def test_order_number_is_generated_when_absent(self):
+        order = make_order()
+        self.assertTrue(order.order_number)
+        self.assertEqual(len(order.order_number), 32)
+
+    def test_order_numbers_are_unique(self):
+        numbers = {make_order().order_number for _ in range(5)}
+        self.assertEqual(len(numbers), 5)
+
+    def test_an_existing_order_number_is_not_regenerated(self):
+        order = make_order()
+        original = order.order_number
+        order.full_name = "Grace Hopper"
+        order.save()
+        self.assertEqual(order.order_number, original)
+
+
+class LineItemTests(TestCase):
+    def setUp(self):
+        self.release = make_release(price="19.99")
+        self.order = make_order()
+
+    def test_lineitem_total_is_price_times_quantity(self):
+        item = OrderLineItem.objects.create(
+            order=self.order, release=self.release, quantity=3
+        )
+        self.assertEqual(item.lineitem_total, Decimal("59.97"))
+
+    def test_saving_a_lineitem_updates_the_order_subtotal(self):
+        OrderLineItem.objects.create(
+            order=self.order, release=self.release, quantity=2
+        )
+        self.order.refresh_from_db()
+        self.assertEqual(self.order.subtotal, Decimal("39.98"))
+
+    def test_a_second_lineitem_adds_to_the_subtotal(self):
+        other = make_release(title="Onibaba", price="10.00")
+        OrderLineItem.objects.create(
+            order=self.order, release=self.release, quantity=1
+        )
+        OrderLineItem.objects.create(
+            order=self.order, release=other, quantity=1
+        )
+        self.order.refresh_from_db()
+        self.assertEqual(self.order.subtotal, Decimal("29.99"))
+
+
+class OrderTotalTests(TestCase):
+    """
+    Delivery is charged at DELIVERY_RATE percent of the subtotal until the
+    subtotal reaches FREE_DELIVERY, at which point it is nothing.
+    """
+
+    def setUp(self):
+        self.order = make_order()
+
+    def add(self, price, quantity=1):
+        release = make_release(title=f"Release {price}", price=price)
+        OrderLineItem.objects.create(
+            order=self.order, release=release, quantity=quantity
+        )
+        self.order.refresh_from_db()
+
+    def test_delivery_is_charged_below_the_free_threshold(self):
+        self.add("20.00")
+        expected = (
+            Decimal("20.00") * Decimal(settings.DELIVERY_RATE) / Decimal("100")
+        )
+        self.assertEqual(self.order.delivery_cost, expected)
+
+    def test_delivery_is_free_at_exactly_the_threshold(self):
+        self.add(str(settings.FREE_DELIVERY))
+        self.assertEqual(self.order.delivery_cost, Decimal("0.00"))
+
+    def test_delivery_is_free_above_the_threshold(self):
+        self.add(str(settings.FREE_DELIVERY + 1))
+        self.assertEqual(self.order.delivery_cost, Decimal("0.00"))
+
+    def test_total_is_subtotal_plus_delivery(self):
+        self.add("20.00")
+        self.assertEqual(
+            self.order.total,
+            self.order.subtotal + self.order.delivery_cost,
+        )
+
+    def test_discount_is_subtracted_from_the_total(self):
+        self.add(str(settings.FREE_DELIVERY))
+        self.order.discount = Decimal("10.00")
+        self.order.update_total()
+        self.assertEqual(
+            self.order.total,
+            Decimal(settings.FREE_DELIVERY) - Decimal("10.00"),
+        )
+
+    def test_total_never_goes_negative(self):
+        """
+        A discount larger than the order should floor at zero rather than
+        producing a negative charge.
+        """
+        self.add("20.00")
+        self.order.discount = Decimal("9999.00")
+        self.order.update_total()
+        self.assertEqual(self.order.total, Decimal("0.00"))
+
+    def test_totals_are_rounded_to_two_places(self):
+        self.add("19.99", quantity=3)
+        for value in (
+            self.order.subtotal,
+            self.order.delivery_cost,
+            self.order.total,
+        ):
+            self.assertEqual(value, value.quantize(Decimal("0.01")))
+
+    def test_an_order_with_no_lineitems_has_a_zero_subtotal(self):
+        self.order.update_total()
+        self.assertEqual(self.order.subtotal, Decimal("0.00"))
+
+
+class DiscountCodeTests(TestCase):
+    def make_code(self, code="CULT10", percent=10, days_from=-1, days_to=1,
+                  is_active=True):
+        today = timezone.now().date()
+        return DiscountCode.objects.create(
+            code=code,
+            percent=percent,
+            valid_from=today + timedelta(days=days_from),
+            valid_to=today + timedelta(days=days_to),
+            is_active=is_active,
+        )
+
+    def test_a_current_active_code_is_valid(self):
+        self.assertTrue(self.make_code().is_valid())
+
+    def test_an_inactive_code_is_not_valid(self):
+        self.assertFalse(self.make_code(is_active=False).is_valid())
+
+    def test_a_code_that_has_expired_is_not_valid(self):
+        self.assertFalse(self.make_code(days_from=-10, days_to=-1).is_valid())
+
+    def test_a_code_that_has_not_started_is_not_valid(self):
+        self.assertFalse(self.make_code(days_from=1, days_to=10).is_valid())
+
+    def test_a_code_is_valid_on_its_first_day(self):
+        self.assertTrue(self.make_code(days_from=0, days_to=5).is_valid())
+
+    def test_a_code_is_valid_on_its_last_day(self):
+        self.assertTrue(self.make_code(days_from=-5, days_to=0).is_valid())
+
+
+class ApplyDiscountViewTests(TestCase):
+    def setUp(self):
+        today = timezone.now().date()
+        self.code = DiscountCode.objects.create(
+            code="CULT10",
+            percent=10,
+            valid_from=today - timedelta(days=1),
+            valid_to=today + timedelta(days=1),
+        )
+        self.url = reverse("apply_discount")
+
+    def test_a_valid_code_is_stored_in_the_session(self):
+        self.client.post(self.url, {"discount_code": "CULT10"})
+        self.assertEqual(self.client.session["discount_code"], "CULT10")
+        self.assertEqual(self.client.session["discount_percent"], 10)
+
+    def test_a_code_is_matched_case_insensitively(self):
+        self.client.post(self.url, {"discount_code": "cult10"})
+        self.assertEqual(self.client.session["discount_percent"], 10)
+
+    def test_surrounding_whitespace_is_ignored(self):
+        self.client.post(self.url, {"discount_code": "  CULT10  "})
+        self.assertEqual(self.client.session["discount_percent"], 10)
+
+    def test_an_unknown_code_clears_the_session(self):
+        self.client.post(self.url, {"discount_code": "NOPE"})
+        self.assertEqual(self.client.session["discount_code"], "")
+        self.assertEqual(self.client.session["discount_percent"], 0)
+
+    def test_an_expired_code_clears_the_session(self):
+        today = timezone.now().date()
+        DiscountCode.objects.create(
+            code="OLD",
+            percent=50,
+            valid_from=today - timedelta(days=10),
+            valid_to=today - timedelta(days=5),
+        )
+        self.client.post(self.url, {"discount_code": "OLD"})
+        self.assertEqual(self.client.session["discount_percent"], 0)
+
+    def test_an_expired_code_replaces_a_previously_applied_one(self):
+        """
+        The dangerous case: a good code is applied, then a bad one is tried.
+        The bad attempt must clear the good discount rather than leave it.
+        """
+        self.client.post(self.url, {"discount_code": "CULT10"})
+        self.client.post(self.url, {"discount_code": "NOPE"})
+        self.assertEqual(self.client.session["discount_percent"], 0)
+
+    def test_it_redirects_to_the_cart(self):
+        response = self.client.post(self.url, {"discount_code": "CULT10"})
+        self.assertRedirects(response, reverse("cart"))
+
+
+class CartContextTests(TestCase):
+    """
+    The context processor that every template reads its cart figures from.
+    """
+
+    def setUp(self):
+        self.release = make_release(price="20.00")
+
+    def set_cart(self, cart, **session):
+        s = self.client.session
+        s["cart"] = cart
+        for key, value in session.items():
+            s[key] = value
+        s.save()
+
+    def context(self):
+        return self.client.get(reverse("cart")).context
+
+    def test_an_empty_cart_reports_zeroes(self):
+        context = self.context()
+        self.assertEqual(context["subtotal"], Decimal("0.00"))
+        self.assertEqual(context["total"], Decimal("0.00"))
+        self.assertEqual(context["total_quantity"], 0)
+        self.assertEqual(context["purchases"], [])
+
+    def test_an_empty_cart_reports_the_full_free_delivery_gap(self):
+        self.assertEqual(
+            self.context()["free_delivery_diff"], settings.FREE_DELIVERY
+        )
+
+    def test_subtotal_and_quantity_reflect_the_cart(self):
+        self.set_cart({str(self.release.id): 2})
+        context = self.context()
+        self.assertEqual(context["subtotal"], Decimal("40.00"))
+        self.assertEqual(context["total_quantity"], 2)
+
+    def test_delivery_is_charged_below_the_threshold(self):
+        self.set_cart({str(self.release.id): 1})
+        expected = (
+            Decimal("20.00") * Decimal(settings.DELIVERY_RATE) / Decimal("100")
+        )
+        self.assertEqual(self.context()["delivery"], expected)
+
+    def test_delivery_is_free_once_the_threshold_is_reached(self):
+        quantity = (settings.FREE_DELIVERY // 20) + 1
+        self.set_cart({str(self.release.id): quantity})
+        context = self.context()
+        self.assertEqual(context["delivery"], Decimal("0.00"))
+        self.assertEqual(context["free_delivery_diff"], Decimal("0.00"))
+
+    def test_a_discount_percent_reduces_the_total(self):
+        self.set_cart(
+            {str(self.release.id): 1},
+            discount_code="CULT10",
+            discount_percent=10,
+        )
+        context = self.context()
+        self.assertEqual(context["discount_amount"], Decimal("2.00"))
+        self.assertEqual(
+            context["total"],
+            context["subtotal"] + context["delivery"] - Decimal("2.00"),
+        )
+
+    # A release deleted while sitting in someone's cart currently takes the
+    # whole site down for them, because the context processor raises Http404
+    # during template binding and the error page re-runs the same processor.
+    # Raised as issue #129 rather than covered here: a test asserting a crash
+    # would pass for the wrong reason, and the fix belongs with the fix.
+
+
+class CartViewTests(TestCase):
+    def setUp(self):
+        self.release = make_release()
+
+    def test_the_cart_page_renders(self):
+        self.assertEqual(self.client.get(reverse("cart")).status_code, 200)
+
+    def test_adding_a_release_puts_it_in_the_session(self):
+        self.client.post(
+            reverse("add_to_cart", args=[self.release.id]),
+            {"quantity": 2, "redirect_url": reverse("cart")},
+        )
+        self.assertEqual(
+            self.client.session["cart"].get(str(self.release.id)), 2
+        )
+
+    def test_removing_a_release_empties_the_session(self):
+        self.client.post(
+            reverse("add_to_cart", args=[self.release.id]),
+            {"quantity": 1, "redirect_url": reverse("cart")},
+        )
+        self.client.post(
+            reverse("remove_from_cart", args=[self.release.id])
+        )
+        self.assertNotIn(
+            str(self.release.id), self.client.session.get("cart", {})
+        )
+
+
+class CheckoutAccessTests(TestCase):
+    def test_checkout_requires_login(self):
+        response = self.client.get(reverse("checkout"))
+        self.assertEqual(response.status_code, 302)
+        self.assertIn("/accounts/login/", response.url)
+
+    def test_discount_code_management_is_refused_to_ordinary_users(self):
+        User.objects.create_user(
+            username="member", email="m@example.com", password="pw-for-test"
+        )
+        self.client.login(username="member", password="pw-for-test")
+        response = self.client.get(reverse("discount_codes_management"))
+        self.assertNotEqual(response.status_code, 200)
+
+
+class WebhookTests(TestCase):
+    """
+    The endpoint is unauthenticated and CSRF-exempt, so the signature check is
+    the only thing standing between a stranger and the order handler.
+    """
+
+    def test_an_unsigned_request_is_rejected(self):
+        response = self.client.post(
+            reverse("webhook"),
+            data="{}",
+            content_type="application/json",
+        )
+        self.assertEqual(response.status_code, 400)
+
+    def test_a_forged_signature_is_rejected(self):
+        response = self.client.post(
+            reverse("webhook"),
+            data='{"type": "payment_intent.succeeded"}',
+            content_type="application/json",
+            HTTP_STRIPE_SIGNATURE="t=1,v1=not-a-real-signature",
+        )
+        self.assertEqual(response.status_code, 400)
+
+    def test_a_rejected_webhook_creates_no_order(self):
+        self.client.post(
+            reverse("webhook"),
+            data='{"type": "payment_intent.succeeded"}',
+            content_type="application/json",
+            HTTP_STRIPE_SIGNATURE="t=1,v1=not-a-real-signature",
+        )
+        self.assertEqual(Order.objects.count(), 0)

--- a/the_cult_film_club/apps/contact/tests.py
+++ b/the_cult_film_club/apps/contact/tests.py
@@ -1,3 +1,67 @@
-from django.test import TestCase
+"""
+Tests for the contact form and the notification it sends.
+"""
 
-# Create your tests here.
+from django.core import mail
+from django.test import TestCase
+from django.urls import reverse
+
+from the_cult_film_club.apps.contact.forms import ContactUsForm
+from the_cult_film_club.apps.contact.models import ContactUs
+
+VALID = {
+    "first_name": "Ada",
+    "last_name": "Lovelace",
+    "email": "ada@example.com",
+    "message": "Do you stock Onibaba on 4K?",
+}
+
+
+class ContactFormTests(TestCase):
+    def test_a_complete_submission_is_valid(self):
+        self.assertTrue(ContactUsForm(data=VALID).is_valid())
+
+    def test_an_invalid_email_is_rejected(self):
+        form = ContactUsForm(data={**VALID, "email": "not-an-address"})
+        self.assertFalse(form.is_valid())
+        self.assertIn("email", form.errors)
+
+    def test_every_field_is_required(self):
+        form = ContactUsForm(data={})
+        self.assertFalse(form.is_valid())
+        for field in ("first_name", "last_name", "email", "message"):
+            self.assertIn(field, form.errors)
+
+
+class ContactViewTests(TestCase):
+    def setUp(self):
+        self.url = reverse("contact_us")
+
+    def test_the_page_renders(self):
+        self.assertEqual(self.client.get(self.url).status_code, 200)
+
+    def test_a_valid_submission_is_stored(self):
+        self.client.post(self.url, VALID)
+        self.assertEqual(ContactUs.objects.count(), 1)
+        self.assertEqual(ContactUs.objects.first().email, VALID["email"])
+
+    def test_an_invalid_submission_is_not_stored(self):
+        self.client.post(self.url, {**VALID, "email": "nope"})
+        self.assertEqual(ContactUs.objects.count(), 0)
+
+    def test_a_valid_submission_sends_a_notification(self):
+        """
+        The notification was added because enquiries were otherwise only
+        visible by looking in the admin.
+        """
+        self.client.post(self.url, VALID)
+        self.assertEqual(len(mail.outbox), 1)
+
+    def test_the_notification_names_the_sender(self):
+        self.client.post(self.url, VALID)
+        body = mail.outbox[0].body
+        self.assertIn(VALID["email"], body)
+
+    def test_no_notification_is_sent_for_an_invalid_submission(self):
+        self.client.post(self.url, {**VALID, "email": "nope"})
+        self.assertEqual(len(mail.outbox), 0)

--- a/the_cult_film_club/apps/home/tests.py
+++ b/the_cult_film_club/apps/home/tests.py
@@ -1,3 +1,68 @@
-from django.test import TestCase
+"""
+Tests for the landing page and the error handlers.
 
-# Create your tests here.
+The error page tests exist because those templates share the base template and
+its context processors, so a page nobody looks at until something has already
+gone wrong is exactly the page that breaks quietly.
+"""
+
+from decimal import Decimal
+
+from django.test import TestCase
+from django.urls import reverse
+from django.utils import timezone
+
+from the_cult_film_club.apps.releases.models import Images, Releases
+
+
+class HomePageTests(TestCase):
+    def test_the_home_page_renders(self):
+        self.assertEqual(self.client.get(reverse("home")).status_code, 200)
+
+    def test_the_home_page_lists_a_release(self):
+        Releases.objects.create(
+            title="Tourist Trap",
+            release_date=timezone.now().date(),
+            price=Decimal("19.99"),
+        )
+        response = self.client.get(reverse("home"))
+        self.assertContains(response, "Tourist Trap")
+
+    def test_the_home_page_renders_with_no_releases_at_all(self):
+        self.assertEqual(self.client.get(reverse("home")).status_code, 200)
+
+    def test_release_images_are_served_from_cloudfront(self):
+        release = Releases.objects.create(
+            title="Tourist Trap",
+            release_date=timezone.now().date(),
+            price=Decimal("19.99"),
+        )
+        Images.objects.create(
+            title=release, image="releases/hero", is_featured=True
+        )
+        response = self.client.get(reverse("home"))
+        self.assertContains(
+            response, "media.cultfilmclub.dominicfrancis.co.uk"
+        )
+
+    def test_no_cloudinary_url_survives_anywhere_on_the_page(self):
+        """
+        Guards the #116 migration against a regression.
+        """
+        response = self.client.get(reverse("home"))
+        self.assertNotContains(response, "res.cloudinary.com")
+
+
+class ErrorPageTests(TestCase):
+    def test_an_unknown_url_returns_a_404(self):
+        response = self.client.get("/no-such-page-exists/")
+        self.assertEqual(response.status_code, 404)
+
+    def test_the_404_page_renders_rather_than_erroring(self):
+        """
+        The 404 template extends base.html, so it runs every context
+        processor. If one of those raises, the error page cannot render and
+        the failure becomes a 500 instead.
+        """
+        response = self.client.get("/no-such-page-exists/")
+        self.assertContains(response, "Cult Film Club", status_code=404)

--- a/the_cult_film_club/apps/newsletter/tests.py
+++ b/the_cult_film_club/apps/newsletter/tests.py
@@ -1,3 +1,160 @@
-from django.test import TestCase
+"""
+Tests for newsletter signup, preferences and token-based unsubscribe.
 
-# Create your tests here.
+The unsubscribe token is the interesting part: it is the only thing standing
+between a stranger and someone else's subscription, since the link carries no
+authentication.
+"""
+
+from decimal import Decimal
+from uuid import uuid4
+
+from django.test import TestCase
+from django.urls import reverse
+from django.utils import timezone
+
+from the_cult_film_club.apps.newsletter.forms import NewsletterSignupForm
+from the_cult_film_club.apps.newsletter.models import NewsletterSignup
+from the_cult_film_club.apps.releases.models import Releases
+
+
+class SignupModelTests(TestCase):
+    def test_each_subscriber_gets_an_unsubscribe_token(self):
+        signup = NewsletterSignup.objects.create(email="ada@example.com")
+        self.assertIsNotNone(signup.unsubscribe_token)
+
+    def test_tokens_differ_between_subscribers(self):
+        a = NewsletterSignup.objects.create(email="a@example.com")
+        b = NewsletterSignup.objects.create(email="b@example.com")
+        self.assertNotEqual(a.unsubscribe_token, b.unsubscribe_token)
+
+    def test_an_email_can_only_subscribe_once(self):
+        from django.db import IntegrityError
+
+        NewsletterSignup.objects.create(email="ada@example.com")
+        with self.assertRaises(IntegrityError):
+            NewsletterSignup.objects.create(email="ada@example.com")
+
+    def test_subscribers_are_ordered_newest_first(self):
+        first = NewsletterSignup.objects.create(email="first@example.com")
+        second = NewsletterSignup.objects.create(email="second@example.com")
+        self.assertEqual(
+            list(NewsletterSignup.objects.all()), [second, first]
+        )
+
+
+class SignupFormTests(TestCase):
+    def setUp(self):
+        Releases.objects.create(
+            title="Tourist Trap",
+            release_date=timezone.now().date(),
+            price=Decimal("19.99"),
+            genre="Horror",
+        )
+
+    def test_genre_choices_come_from_the_catalogue(self):
+        form = NewsletterSignupForm()
+        self.assertIn(("Horror", "Horror"), form.fields["genres"].choices)
+
+    def test_a_signup_with_a_genre_is_valid(self):
+        form = NewsletterSignupForm(
+            data={"email": "ada@example.com", "genres": ["Horror"]}
+        )
+        self.assertTrue(form.is_valid())
+
+    def test_genres_are_stored_comma_separated(self):
+        Releases.objects.create(
+            title="Onibaba",
+            release_date=timezone.now().date(),
+            price=Decimal("19.99"),
+            genre="Drama",
+        )
+        form = NewsletterSignupForm(
+            data={"email": "ada@example.com", "genres": ["Horror", "Drama"]}
+        )
+        self.assertTrue(form.is_valid())
+        self.assertEqual(form.cleaned_data["genres"], "Horror,Drama")
+
+    def test_a_genre_that_is_not_in_the_catalogue_is_rejected(self):
+        form = NewsletterSignupForm(
+            data={"email": "ada@example.com", "genres": ["Musical"]}
+        )
+        self.assertFalse(form.is_valid())
+
+
+class UnsubscribeTests(TestCase):
+    def setUp(self):
+        self.signup = NewsletterSignup.objects.create(email="ada@example.com")
+
+    def url_for(self, token):
+        return reverse("newsletter_unsubscribe", args=[token])
+
+    def test_a_get_shows_a_confirmation_and_removes_nobody(self):
+        """
+        Worth asserting rather than assuming. An unsubscribe link lands in an
+        inbox, where mail clients and scanners fetch URLs on their own, so a
+        GET that deleted the record would unsubscribe people who never
+        clicked anything.
+        """
+        response = self.client.get(
+            self.url_for(self.signup.unsubscribe_token)
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(
+            NewsletterSignup.objects.filter(email="ada@example.com").exists()
+        )
+
+    def test_a_post_with_the_correct_token_unsubscribes(self):
+        self.client.post(self.url_for(self.signup.unsubscribe_token))
+        self.assertFalse(
+            NewsletterSignup.objects.filter(email="ada@example.com").exists()
+        )
+
+    def test_an_unknown_token_is_a_404(self):
+        """
+        The link carries no authentication, so a guessed or stale token must
+        not take anyone off the list.
+        """
+        response = self.client.post(self.url_for(uuid4()))
+        self.assertEqual(response.status_code, 404)
+        self.assertTrue(
+            NewsletterSignup.objects.filter(email="ada@example.com").exists()
+        )
+
+    def test_one_persons_token_does_not_unsubscribe_another(self):
+        other = NewsletterSignup.objects.create(email="grace@example.com")
+        self.client.post(self.url_for(other.unsubscribe_token))
+        self.assertTrue(
+            NewsletterSignup.objects.filter(email="ada@example.com").exists()
+        )
+        self.assertFalse(
+            NewsletterSignup.objects.filter(email="grace@example.com").exists()
+        )
+
+
+class SignupViewTests(TestCase):
+    def setUp(self):
+        Releases.objects.create(
+            title="Tourist Trap",
+            release_date=timezone.now().date(),
+            price=Decimal("19.99"),
+            genre="Horror",
+        )
+        self.url = reverse("newsletter_signup")
+
+    def test_the_page_renders(self):
+        self.assertEqual(self.client.get(self.url).status_code, 200)
+
+    def test_a_valid_signup_is_stored(self):
+        self.client.post(
+            self.url, {"email": "ada@example.com", "genres": ["Horror"]}
+        )
+        self.assertTrue(
+            NewsletterSignup.objects.filter(email="ada@example.com").exists()
+        )
+
+    def test_an_invalid_email_is_not_stored(self):
+        self.client.post(
+            self.url, {"email": "not-an-address", "genres": ["Horror"]}
+        )
+        self.assertEqual(NewsletterSignup.objects.count(), 0)

--- a/the_cult_film_club/apps/releases/tests.py
+++ b/the_cult_film_club/apps/releases/tests.py
@@ -1,3 +1,160 @@
-from django.test import TestCase
+"""
+Tests for the catalogue: release views, ratings and featured images.
+"""
 
-# Create your tests here.
+from decimal import Decimal
+
+from django.contrib.auth.models import User
+from django.test import TestCase
+from django.urls import reverse
+from django.utils import timezone
+
+from the_cult_film_club.apps.releases.models import Images, Rating, Releases
+
+
+def make_release(title="Tourist Trap", price="19.99", copies=5):
+    return Releases.objects.create(
+        title=title,
+        release_date=timezone.now().date(),
+        price=Decimal(price),
+        copies_available=copies,
+    )
+
+
+class ReleaseViewTests(TestCase):
+    def setUp(self):
+        self.release = make_release()
+
+    def test_the_catalogue_renders(self):
+        self.assertEqual(self.client.get(reverse("releases")).status_code, 200)
+
+    def test_the_catalogue_lists_a_release(self):
+        response = self.client.get(reverse("releases"))
+        self.assertContains(response, self.release.title)
+
+    def test_a_release_detail_page_renders(self):
+        response = self.client.get(
+            reverse("release_details", args=[self.release.id])
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, self.release.title)
+
+    def test_an_unknown_release_is_a_404(self):
+        response = self.client.get(reverse("release_details", args=[999999]))
+        self.assertEqual(response.status_code, 404)
+
+    def test_product_management_is_refused_to_anonymous_visitors(self):
+        response = self.client.get(reverse("product_management"))
+        self.assertNotEqual(response.status_code, 200)
+
+    def test_product_management_is_refused_to_ordinary_users(self):
+        User.objects.create_user(
+            username="member", email="m@example.com", password="pw-for-test"
+        )
+        self.client.login(username="member", password="pw-for-test")
+        response = self.client.get(reverse("product_management"))
+        self.assertNotEqual(response.status_code, 200)
+
+
+class AverageRatingTests(TestCase):
+    def setUp(self):
+        self.release = make_release()
+
+    def rate(self, username, score):
+        user = User.objects.create_user(
+            username=username,
+            email=f"{username}@example.com",
+            password="pw-for-test",
+        )
+        Rating.objects.create(user=user, title=self.release, rating=score)
+
+    def test_a_release_with_no_ratings_has_no_average(self):
+        self.assertIsNone(self.release.average_rating)
+
+    def test_a_single_rating_is_its_own_average(self):
+        self.rate("one", 4)
+        self.assertEqual(self.release.average_rating, 4)
+
+    def test_the_average_is_the_mean_of_all_ratings(self):
+        self.rate("one", 5)
+        self.rate("two", 3)
+        self.assertEqual(self.release.average_rating, 4)
+
+    def test_ratings_on_another_release_are_not_counted(self):
+        other = make_release(title="Onibaba")
+        user = User.objects.create_user(
+            username="three", email="t@example.com", password="pw-for-test"
+        )
+        Rating.objects.create(user=user, title=other, rating=1)
+        self.rate("four", 5)
+        self.assertEqual(self.release.average_rating, 5)
+
+    def test_a_user_can_only_rate_a_release_once(self):
+        """
+        Enforced by unique_together on the model.
+        """
+        from django.db import IntegrityError
+
+        user = User.objects.create_user(
+            username="dupe", email="d@example.com", password="pw-for-test"
+        )
+        Rating.objects.create(user=user, title=self.release, rating=3)
+        with self.assertRaises(IntegrityError):
+            Rating.objects.create(user=user, title=self.release, rating=5)
+
+
+class FeaturedImageTests(TestCase):
+    def setUp(self):
+        self.release = make_release()
+
+    def add_image(self, name, featured=False):
+        return Images.objects.create(
+            title=self.release,
+            image=f"releases/{name}",
+            is_featured=featured,
+        )
+
+    def test_a_release_with_no_images_has_no_featured_image(self):
+        self.assertIsNone(self.release.featured_image)
+
+    def test_the_featured_image_is_the_one_marked_featured(self):
+        self.add_image("plain")
+        featured = self.add_image("hero", featured=True)
+        self.assertEqual(self.release.featured_image, featured)
+
+    def test_marking_an_image_featured_unmarks_the_previous_one(self):
+        """
+        Images.save clears the flag on every other image for the release, so
+        a catalogue card can never have two candidates.
+        """
+        first = self.add_image("first", featured=True)
+        self.add_image("second", featured=True)
+
+        first.refresh_from_db()
+        self.assertFalse(first.is_featured)
+        self.assertEqual(
+            Images.objects.filter(
+                title=self.release, is_featured=True
+            ).count(),
+            1,
+        )
+
+    def test_featuring_an_image_does_not_affect_another_release(self):
+        other = make_release(title="Onibaba")
+        other_image = Images.objects.create(
+            title=other, image="releases/other", is_featured=True
+        )
+        self.add_image("mine", featured=True)
+
+        other_image.refresh_from_db()
+        self.assertTrue(other_image.is_featured)
+
+    def test_an_image_defaults_to_the_holding_image(self):
+        image = Images.objects.create(title=self.release)
+        self.assertEqual(image.image.name, "site/holding_image")
+
+    def test_an_image_url_is_served_from_cloudfront(self):
+        image = self.add_image("hero")
+        self.assertTrue(
+            image.image.url.startswith("https://media.cultfilmclub")
+        )

--- a/the_cult_film_club/settings.py
+++ b/the_cult_film_club/settings.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 import os
+import sys
 import dj_database_url
 from decimal import Decimal
 from dotenv import load_dotenv
@@ -12,10 +13,28 @@ SITE_ID = 1
 # Debug mode (should be False in production)
 DEBUG = os.environ.get('DEBUG', 'False') == 'True'
 
+# True while `manage.py test` is running. Added with issue #112.
+#
+# CI runs with DEBUG off, which is right: it should exercise settings as close
+# to production as possible. But SECURE_SSL_REDIRECT below answers every plain
+# HTTP request with a 301, and the Django test client speaks plain HTTP, so
+# with it on every single test gets a 301 where it expected a 200.
+#
+# Checking sys.argv is blunt but honest, and it is confined to this one line.
+# The alternative was to have CI claim DEBUG=True, which would quietly switch
+# the email backend and anything else keyed on it, and would let a test pass
+# for reasons that do not hold in production.
+TESTING = "test" in sys.argv
+
 # Production security, gated on DEBUG the same way the email backend below is.
 # Every one of these is wrong locally, where runserver speaks plain HTTP and
 # enabling them would make the site unreachable.
-if not DEBUG:
+#
+# Skipped under test for the reason above. The settings themselves were
+# verified against the running site when they landed in issue #109, which is
+# the only place they can be checked meaningfully: they describe how the site
+# sits behind nginx, and nothing about that is reproducible in a test client.
+if not DEBUG and not TESTING:
     # TLS terminates at nginx on the apps box, on a Let's Encrypt certificate
     # managed by certbot. gunicorn listens on plain HTTP on 127.0.0.1:8002, so
     # every request Django sees arrives unencrypted and it judges them all
@@ -390,11 +409,28 @@ SESSION_ENGINE = "django.contrib.sessions.backends.db"
 
 # Database configuration (using dj_database_url for parsing DATABASE_URL)
 # DATABASES = {"default": dj_database_url.parse(os.environ.get("DATABASE_URL"))}
+# dj_database_url turns ssl_require into OPTIONS["sslmode"] = "require", and it
+# does that for whichever backend is configured, overriding any sslmode in the
+# URL itself. Requiring TLS to the database is right in production, where the
+# connection leaves the instance.
+#
+# It is wrong everywhere else, and it was blocking issue #112: a Postgres
+# service container in CI has ssl off, so every connection was refused with
+# "server does not support SSL, but SSL was required" before a single test
+# could run. Locally the same clause is why DATABASE_URL has to use a Unix
+# socket, where libpq ignores sslmode.
+#
+# Defaulting to True keeps production exactly as it was: nothing sets this
+# variable there, so nothing changes. CI sets it to False.
+DATABASE_SSL_REQUIRE = (
+    os.environ.get("DATABASE_SSL_REQUIRE", "True") == "True"
+)
+
 DATABASES = {
     'default': dj_database_url.config(
         default=os.environ.get('DATABASE_URL'),
         conn_max_age=600,
-        ssl_require=True
+        ssl_require=DATABASE_SSL_REQUIRE
     )
 }
 


### PR DESCRIPTION
Closes #112.

**106 tests across all seven apps**, replacing seven untouched Django stubs, plus a workflow that runs them on every pull request.

| App | Tests | What is covered |
|---|---:|---|
| `cart` | 41 | Order totals, delivery thresholds, line items, discount codes, the webhook signature |
| `releases` | 17 | Catalogue views, average rating, featured image exclusivity, admin access |
| `newsletter` | 15 | Signup, genre choices, token unsubscribe |
| `account` | 15 | Profile signal, photo deletion, default address, wishlists |
| `contact` | 10 | Form validation, storage, the notification email |
| `home` | 6 | Landing page, error page rendering |
| `about` | 2 | Renders |

Weighted towards the cart on purpose. Order totals, delivery thresholds and discounts are where a regression costs real money, and the webhook is unauthenticated and CSRF-exempt so its signature check is the only thing between a stranger and the order handler.

Every figure is asserted against `settings.FREE_DELIVERY` and `DELIVERY_RATE` rather than a literal, so changing either does not silently invalidate the tests.

## The blocker in the issue, resolved

`ssl_require=True` was passed unconditionally to `dj_database_url`, which sets `sslmode=require` on whatever backend is configured. A Postgres service container has ssl off, so every connection was refused with *"server does not support SSL, but SSL was required"* before a single test could run.

It is now `DATABASE_SSL_REQUIRE`, **defaulting to `True`**. Nothing sets it in production, so production is byte-for-byte unchanged:

| Environment | Value | Resulting `OPTIONS` |
|---|---|---|
| Production, variable unset | `True` | `{'sslmode': 'require'}` |
| CI, set to `False` | `False` | `{}` |

Verified both ways rather than assumed.

## A second blocker, found on the way

`SECURE_SSL_REDIRECT` from #109 answers every plain HTTP request with a 301, and the Django test client speaks plain HTTP. With `DEBUG` off, **all nine of the first tests I ran returned 301 instead of 200**.

Rather than have CI claim `DEBUG=True`, which would quietly switch the email backend and let a test pass for reasons that do not hold in production, settings.py gains a `TESTING` flag and skips the security block while `manage.py test` runs. Those settings were verified against the running site in #109, which is the only place they mean anything: they describe how the site sits behind nginx, and no test client can reproduce that.

CI therefore runs with `DEBUG=False`, as close to production as it can get.

## A real bug, found by the suite

Raised separately as **#129** rather than fixed here.

Deleting a release while it sits in someone's session cart makes **every page on the site** return a 500 for that person, and the error page itself cannot render. `purchases` calls `get_object_or_404` in a context processor, which is not a view: the `Http404` goes to `handler500`, and the 500 template re-runs the same context processor and raises again.

I left it out of this PR because a test asserting a crash passes for the wrong reason, and the fix belongs with the fix. There is a comment at the spot in `cart/tests.py` pointing at the issue.

## Also surfaced

`Order.stripe_pid` is `unique=True` with `default=''`, so **only one order can ever exist without a Stripe payment intent**. The second raises an IntegrityError. Not a live problem, since real orders always carry one, but it is a property of the model rather than a quirk of the tests, and it is noted in the test helper.

## The workflow

Runs on every pull request, and on `main` after merge.

| Step | Why |
|---|---|
| Postgres 18 service container | Production is Postgres, and the project has migrations that would not be exercised the same way elsewhere |
| Health check on the container | Without it the job races startup and the first connection is refused |
| `makemigrations --check --dry-run` | A model changed without a migration fails here rather than part-way through a deploy, after the snapshot and mid-restart |
| `manage.py test --verbosity 2` | The suite |

Same `paths-ignore` as `deploy.yml`, so documentation changes do not spend a minute running tests they cannot break.

## One acceptance criterion I cannot complete

> Merging to `main` is gated on the suite passing, so a failure blocks the deploy

That is a **branch protection setting**, not anything in a file. Until it is switched on, a red run here is advisory and the merge button still works.

It needs the `Tests` check marking as required on `main` in Settings → Branches. I have not changed it, because it alters how the repository behaves for everyone rather than only what this PR contains. Say the word and I will apply it, or it is three clicks in the UI.

## Verified

| Check | Result |
|---|---|
| Suite under CI conditions, `DEBUG=False` | 106 passed |
| Suite under local conditions, `DEBUG=True` | 106 passed |
| `check --deploy`, `DEBUG=False` | no issues, 1 silenced, unchanged from #109 |
| `makemigrations --check --dry-run` | no changes detected |
| Production `sslmode` with the variable unset | `require`, unchanged |
| PEP 8 at 79 columns | clean |
| Workflow YAML parses, triggers and services correct | yes |
