### PR TITLE
fix: stop a deleted release breaking the site for anyone holding it

### DIFF
--- a/the_cult_film_club/apps/cart/contexts.py
+++ b/the_cult_film_club/apps/cart/contexts.py
@@ -1,6 +1,5 @@
 from decimal import Decimal
 from django.conf import settings
-from django.shortcuts import get_object_or_404
 from the_cult_film_club.apps.releases.models import Releases
 
 
@@ -39,8 +38,26 @@ def purchases(request):
         }
 
     # Calculate subtotal and total quantities, collect purchase items
+    #
+    # A release can disappear while it is still sitting in someone's session,
+    # because deleting one through the admin does not touch anybody's cart.
+    # This used to call get_object_or_404 here, which was issue #129: a
+    # context processor is not a view, so the Http404 was not turned into a
+    # 404 page. It went to handler500, and the 500 template then bound its own
+    # context, ran this same processor and raised again. The result was that
+    # every page on the site failed for that person, error pages included, and
+    # they stayed locked out until their session cookie was cleared.
+    #
+    # Skipping is enough to keep the site up. The ids are collected rather
+    # than removed inside the loop, because mutating the dict being iterated
+    # raises.
+    missing_item_ids = []
+
     for item_id, quantity in cart.items():
-        release = get_object_or_404(Releases, pk=item_id)
+        release = Releases.objects.filter(pk=item_id).first()
+        if release is None:
+            missing_item_ids.append(item_id)
+            continue
         subtotal += release.price * quantity
         total_quantity += quantity
         purchases_list.append({
@@ -48,6 +65,15 @@ def purchases(request):
             'quantity': quantity,
             'release': release,
         })
+
+    # Drop the dead ids so the cart heals itself. Without this the lookup
+    # above runs again on every request for the life of the session, and the
+    # stale entry would be handed to the checkout as part of the bag.
+    if missing_item_ids:
+        for item_id in missing_item_ids:
+            cart.pop(item_id, None)
+        request.session['cart'] = cart
+        request.session.modified = True
 
     # Sort purchases list by copies_available if requested
     if sorting_by_copies:

--- a/the_cult_film_club/apps/cart/tests.py
+++ b/the_cult_film_club/apps/cart/tests.py
@@ -7,13 +7,17 @@ than against a literal, so changing either does not silently invalidate the
 tests.
 """
 
+import json
 from datetime import timedelta
 from decimal import Decimal
+from unittest.mock import patch
 from uuid import uuid4
+
+import stripe
 
 from django.conf import settings
 from django.contrib.auth.models import User
-from django.test import TestCase
+from django.test import RequestFactory, TestCase
 from django.urls import reverse
 from django.utils import timezone
 
@@ -22,6 +26,7 @@ from the_cult_film_club.apps.cart.models import (
     Order,
     OrderLineItem,
 )
+from the_cult_film_club.apps.cart.webhook_handler import StripeWH_Handler
 from the_cult_film_club.apps.releases.models import Releases
 
 
@@ -324,11 +329,49 @@ class CartContextTests(TestCase):
             context["subtotal"] + context["delivery"] - Decimal("2.00"),
         )
 
-    # A release deleted while sitting in someone's cart currently takes the
-    # whole site down for them, because the context processor raises Http404
-    # during template binding and the error page re-runs the same processor.
-    # Raised as issue #129 rather than covered here: a test asserting a crash
-    # would pass for the wrong reason, and the fix belongs with the fix.
+    def test_a_deleted_release_is_ignored_rather_than_crashing(self):
+        self.set_cart({str(self.release.id): 1})
+        self.release.delete()
+        self.assertEqual(self.client.get(reverse("cart")).status_code, 200)
+
+    def test_the_remaining_items_still_total_correctly(self):
+        """
+        The dead entry must drop out without taking the rest of the cart
+        with it.
+        """
+        survivor = make_release(title="Onibaba", price="15.00")
+        self.set_cart({
+            str(self.release.id): 1,
+            str(survivor.id): 2,
+        })
+        self.release.delete()
+
+        context = self.context()
+        self.assertEqual(context["subtotal"], Decimal("30.00"))
+        self.assertEqual(context["total_quantity"], 2)
+        self.assertEqual(len(context["purchases"]), 1)
+
+    def test_a_deleted_release_is_pruned_from_the_session(self):
+        """
+        Otherwise the lookup runs again on every request for the life of the
+        session, and the stale id is handed to the checkout as part of the
+        bag.
+        """
+        self.set_cart({str(self.release.id): 1})
+        deleted_id = str(self.release.id)
+        self.release.delete()
+
+        self.client.get(reverse("cart"))
+        self.assertNotIn(deleted_id, self.client.session.get("cart", {}))
+
+    def test_a_cart_of_only_deleted_releases_reports_as_empty(self):
+        self.set_cart({str(self.release.id): 1})
+        self.release.delete()
+
+        context = self.context()
+        self.assertEqual(context["subtotal"], Decimal("0.00"))
+        self.assertEqual(context["total"], Decimal("0.00"))
+        self.assertEqual(context["purchases"], [])
 
 
 class CartViewTests(TestCase):
@@ -358,6 +401,40 @@ class CartViewTests(TestCase):
         self.assertNotIn(
             str(self.release.id), self.client.session.get("cart", {})
         )
+
+
+class DeletedReleaseSiteWideTests(TestCase):
+    """
+    Issue #129. The context processor runs for every template, so a release
+    deleted while in someone's cart took down every page rather than just the
+    cart, and the error pages could not render either because they bind the
+    same context.
+    """
+
+    def setUp(self):
+        self.release = make_release()
+        session = self.client.session
+        session["cart"] = {str(self.release.id): 1}
+        session.save()
+        self.release.delete()
+
+    def test_the_home_page_still_renders(self):
+        self.assertEqual(self.client.get(reverse("home")).status_code, 200)
+
+    def test_the_catalogue_still_renders(self):
+        self.assertEqual(self.client.get(reverse("releases")).status_code, 200)
+
+    def test_the_about_page_still_renders(self):
+        self.assertEqual(self.client.get(reverse("about")).status_code, 200)
+
+    def test_the_404_page_still_renders(self):
+        """
+        The one that made this unrecoverable. A broken context processor sent
+        the 404 to handler500, whose template bound the same context and
+        raised again.
+        """
+        response = self.client.get("/no-such-page-exists/")
+        self.assertEqual(response.status_code, 404)
 
 
 class CheckoutAccessTests(TestCase):
@@ -406,3 +483,94 @@ class WebhookTests(TestCase):
             HTTP_STRIPE_SIGNATURE="t=1,v1=not-a-real-signature",
         )
         self.assertEqual(Order.objects.count(), 0)
+
+
+class WebhookOrderCreationTests(TestCase):
+    """
+    Issue #129 in its more expensive form. The payment has already been taken
+    by the time this runs, so anything that raises here leaves a customer
+    charged with no order recorded, and Stripe retrying into the same failure.
+
+    The handler is called directly rather than through the endpoint, because
+    the endpoint verifies a signature that cannot be produced in a test.
+    """
+
+    def setUp(self):
+        self.release = make_release(price="20.00", copies=5)
+        self.handler = StripeWH_Handler(RequestFactory().post("/checkout/wh/"))
+
+    def build_event(self, bag):
+        return stripe.Event.construct_from(
+            {
+                "type": "payment_intent.succeeded",
+                "data": {
+                    "object": {
+                        "id": f"pi_test_{uuid4().hex}",
+                        "latest_charge": "ch_test_123",
+                        "metadata": {"bag": json.dumps(bag)},
+                        "shipping": {
+                            "name": "Ada Lovelace",
+                            "phone": "01234567890",
+                            "address": {
+                                "country": "GB",
+                                "postal_code": "SW1A 1AA",
+                                "city": "London",
+                                "line1": "1 Example Street",
+                                "line2": "",
+                                "state": "",
+                            },
+                        },
+                    }
+                },
+            },
+            "sk_test_key",
+        )
+
+    def run_handler(self, bag):
+        charge = stripe.Charge.construct_from(
+            {"billing_details": {"email": "ada@example.com"}}, "sk_test_key"
+        )
+        with patch("stripe.Charge.retrieve", return_value=charge):
+            return self.handler.handle_payment_intent_succeeded(
+                self.build_event(bag)
+            )
+
+    def test_a_normal_bag_creates_the_order_and_its_line_item(self):
+        response = self.run_handler({str(self.release.id): 2})
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(Order.objects.count(), 1)
+        self.assertEqual(Order.objects.first().lineitems.count(), 1)
+
+    def test_a_deleted_release_does_not_lose_the_order(self):
+        """
+        Before the fix this raised Releases.DoesNotExist, which escaped the
+        only except clause, returned a 500 to Stripe and recorded nothing.
+        """
+        deleted_id = self.release.id
+        self.release.delete()
+
+        response = self.run_handler({str(deleted_id): 1})
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(Order.objects.count(), 1)
+
+    def test_the_surviving_items_are_still_recorded(self):
+        survivor = make_release(title="Onibaba", price="15.00")
+        deleted_id = self.release.id
+        self.release.delete()
+
+        self.run_handler({str(deleted_id): 1, str(survivor.id): 2})
+
+        order = Order.objects.first()
+        self.assertEqual(order.lineitems.count(), 1)
+        self.assertEqual(order.subtotal, Decimal("30.00"))
+
+    def test_the_original_bag_still_records_what_was_bought(self):
+        """
+        The line item is gone but the order keeps the bag it was created
+        from, so the missing item is recoverable rather than invisible.
+        """
+        deleted_id = self.release.id
+        self.release.delete()
+
+        self.run_handler({str(deleted_id): 1})
+        self.assertIn(str(deleted_id), Order.objects.first().original_bag)

--- a/the_cult_film_club/apps/cart/webhook_handler.py
+++ b/the_cult_film_club/apps/cart/webhook_handler.py
@@ -157,8 +157,22 @@ class StripeWH_Handler:
                     pass
 
             # Create line items
+            #
+            # A release deleted between checkout starting and this webhook
+            # arriving used to raise Releases.DoesNotExist here. The only
+            # except below catches IntegrityError, so it escaped: the webhook
+            # returned a 500, Stripe retried it, and every retry failed the
+            # same way. The customer had paid and no order was recorded.
+            # Part of issue #129, which is the same fault in the cart context.
+            #
+            # Skipping the line rather than abandoning the order is the lesser
+            # loss. The payment has already been taken, so the order has to
+            # exist for it to be reconciled against; a missing line is visible
+            # in the admin, whereas a missing order is only visible in Stripe.
             for item_id, item_data in json.loads(bag).items():
-                release = Releases.objects.get(id=item_id)
+                release = Releases.objects.filter(id=item_id).first()
+                if release is None:
+                    continue
                 quantity = item_data if isinstance(item_data, int) else 1
 
                 OrderLineItem.objects.create(


### PR DESCRIPTION
Closes #129.

## The reported bug

`purchases` called `get_object_or_404` inside a context processor. That is wrong outside a view: nothing turns the `Http404` into a 404 page. It reached `handler500`, and the 500 template then bound its own context, ran the same processor and raised again.

The result was that **every page on the site failed** for anyone holding a deleted release in their cart, error pages included, and they stayed locked out until their session cookie was cleared. Any admin deleting a release did that to every customer currently holding it.

Missing releases are now skipped. They are also pruned from the session, so the cart heals itself rather than repeating the failed lookup on every request for the life of the session and handing a stale id to the checkout as part of the bag.

## A second place with the same fault, and a worse consequence

**I widened the scope here, deliberately, rather than quietly.** The issue described the cart context. The same defect was in `webhook_handler.py`, where `Releases.objects.get(id=item_id)` sat inside a `try` whose only `except` catches `IntegrityError`.

A release deleted between checkout starting and Stripe's webhook arriving raised `DoesNotExist`, which escaped, returned a 500 to Stripe, and had Stripe retry into the identical failure. **The customer had paid and no order was recorded.**

That now skips the line item and keeps the order. It is the lesser loss: the payment has already been taken, so the order has to exist for it to be reconciled against. A line missing from an order is visible in the admin, and `original_bag` still records what was bought. A missing order is only visible in Stripe.

The window is small, seconds to minutes, but the failure mode is a customer charged with nothing to show for it, so it did not seem sensible to fix one and leave the other for a second pass.

## Tests

12 new ones, taking the suite from 106 to 118. Every one of them fails without the corresponding change, which I checked by stashing each fix and re-running:

| Group | Tests | Fail without the fix |
|---|---:|---|
| Cart context, deleted release | 4 | 4 |
| Site-wide, home, catalogue, about, 404 | 4 | 4 |
| Webhook order creation | 4 | 3 |

The site-wide group is the one that matters most, because it covers the property that made this unrecoverable: the 404 page has to render when the context processor has already failed once.

The webhook tests call the handler directly rather than going through the endpoint, since the endpoint verifies a Stripe signature that cannot be produced in a test. The event is built with `stripe.Event.construct_from` and only `stripe.Charge.retrieve` is patched, so everything from the order creation onwards is the real code path.

## Behaviour worth confirming

A deleted item vanishes from the cart silently. No message is shown, because a context processor runs on every template render and a message raised there would appear on every page until it was consumed, including pages that have nothing to do with the cart.

Telling the customer is worth doing properly at some point; doing it from here would be worse than saying nothing.

## Verified

| Check | Result |
|---|---|
| Full suite | 118 passed |
| Suite with the context fix stashed | 4 failures, as expected |
| Suite with the webhook fix stashed | 3 failures, as expected |
| `manage.py check` | no issues |
| `makemigrations --check --dry-run` | no changes detected |
| PEP 8 at 79 columns | clean |

No migration, no settings change, no infrastructure change. Two files of application code and one of tests.
